### PR TITLE
feat: add agent event logging and manual LLM workflow

### DIFF
--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -1,0 +1,99 @@
+name: PR Validation
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+      - "cursor/**"
+  workflow_dispatch:
+    inputs:
+      task:
+        description: "Optional natural language task to run through AdaptiveAgent"
+        required: false
+        default: ""
+      tool:
+        description: "Optional explicit tool name, e.g. echo or list_files"
+        required: false
+        default: ""
+      tool_arg:
+        description: "Optional tool argument in key=value form"
+        required: false
+        default: ""
+
+jobs:
+  test:
+    name: Unit tests and CLI smoke checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install pytest
+
+      - name: Run unit tests
+        run: |
+          python -m unittest discover
+          pytest
+
+      - name: Compile source
+        run: python -m compileall adaptive_agent tests
+
+      - name: CLI smoke - list tools
+        run: python -m adaptive_agent --list-tools
+
+      - name: CLI smoke - JSON echo tool
+        run: python -m adaptive_agent --json --tool echo --arg task="hello from ci"
+
+      - name: CLI smoke - requirements analysis
+        run: python -m adaptive_agent --json --tool analyze_requirements
+
+  manual-cli:
+    name: Manual CLI run
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run explicit tool when provided
+        if: ${{ inputs.tool != '' }}
+        run: |
+          if [ -n "${{ inputs.tool_arg }}" ]; then
+            python -m adaptive_agent --json --tool "${{ inputs.tool }}" --arg "${{ inputs.tool_arg }}"
+          else
+            python -m adaptive_agent --json --tool "${{ inputs.tool }}"
+          fi
+
+      - name: Run natural language task when provided
+        if: ${{ inputs.task != '' && inputs.tool == '' }}
+        run: python -m adaptive_agent --json "${{ inputs.task }}"
+
+      - name: Show usage when no input provided
+        if: ${{ inputs.task == '' && inputs.tool == '' }}
+        run: |
+          python -m adaptive_agent --list-tools
+          echo "Provide either 'tool' or 'task' in workflow_dispatch inputs to run an interactive-style remote check."

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -148,20 +148,56 @@ jobs:
           INPUT_TOOL: ${{ inputs.tool }}
           INPUT_TOOL_ARG: ${{ inputs.tool_arg }}
         run: |
+          echo "## AdaptiveAgent manual CLI result" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Mode: explicit tool" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Tool: \`$INPUT_TOOL\`" >> "$GITHUB_STEP_SUMMARY"
           if [ -n "$INPUT_TOOL_ARG" ]; then
-            python -m adaptive_agent --json --tool "$INPUT_TOOL" --arg "$INPUT_TOOL_ARG"
-          else
-            python -m adaptive_agent --json --tool "$INPUT_TOOL"
+            echo "- Tool arg: \`$INPUT_TOOL_ARG\`" >> "$GITHUB_STEP_SUMMARY"
           fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`json" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "$INPUT_TOOL_ARG" ]; then
+            python -m adaptive_agent --json --tool "$INPUT_TOOL" --arg "$INPUT_TOOL_ARG" | tee -a "$GITHUB_STEP_SUMMARY"
+          else
+            python -m adaptive_agent --json --tool "$INPUT_TOOL" | tee -a "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Run natural language task when provided
         if: ${{ inputs.task != '' && inputs.tool == '' }}
         env:
+          INPUT_LLM_PROVIDER: ${{ inputs.llm_provider }}
+          INPUT_LLM_MODEL: ${{ inputs.llm_model }}
           INPUT_TASK: ${{ inputs.task }}
-        run: python -m adaptive_agent --json "$INPUT_TASK"
+        run: |
+          echo "## AdaptiveAgent manual LLM result" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Provider: \`$INPUT_LLM_PROVIDER\`" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "$INPUT_LLM_MODEL" ]; then
+            echo "- Requested model: \`$INPUT_LLM_MODEL\`" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "- Effective ADAPTIVE_AGENT_LLM: \`$ADAPTIVE_AGENT_LLM\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Effective Ollama model: \`${OLLAMA_MODEL:-n/a}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Effective OpenAI model: \`${OPENAI_MODEL:-n/a}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Effective Gemini model: \`${GEMINI_MODEL:-n/a}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Task: \`$INPUT_TASK\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`json" >> "$GITHUB_STEP_SUMMARY"
+          python -m adaptive_agent --json "$INPUT_TASK" | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
 
       - name: Show usage when no input provided
         if: ${{ inputs.task == '' && inputs.tool == '' }}
         run: |
           python -m adaptive_agent --list-tools
+          {
+            echo "## AdaptiveAgent manual CLI usage"
+            echo ""
+            echo "Provide either \`tool\` or \`task\` in workflow_dispatch inputs."
+            echo ""
+            echo "- Tool example: \`tool=echo\`, \`tool_arg=task=hello\`"
+            echo "- Ollama example: \`llm_provider=ollama\`, \`task=AdaptiveAgent 요약해줘\`"
+            echo "- OpenAI/Gemini require repository secrets."
+          } >> "$GITHUB_STEP_SUMMARY"
           echo "Provide either 'tool' or 'task' in workflow_dispatch inputs to run an interactive-style remote check."

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -10,6 +10,14 @@ on:
       - "cursor/**"
   workflow_dispatch:
     inputs:
+      llm_provider:
+        description: "LLM provider for natural language task: ollama, openai, gemini, or none"
+        required: false
+        default: "ollama"
+      llm_model:
+        description: "Optional model override for the selected provider"
+        required: false
+        default: ""
       task:
         description: "Optional natural language task to run through AdaptiveAgent"
         required: false
@@ -61,6 +69,10 @@ jobs:
     name: Manual CLI run
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -76,18 +88,77 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r requirements.txt
 
+      - name: Configure selected LLM provider
+        env:
+          INPUT_LLM_PROVIDER: ${{ inputs.llm_provider }}
+          INPUT_LLM_MODEL: ${{ inputs.llm_model }}
+        run: |
+          provider="$INPUT_LLM_PROVIDER"
+          model="$INPUT_LLM_MODEL"
+          {
+            echo "ADAPTIVE_AGENT_LLM=${provider}"
+            if [ "$provider" = "ollama" ] && [ -n "$model" ]; then
+              echo "OLLAMA_MODEL=${model}"
+            fi
+            if [ "$provider" = "openai" ] && [ -n "$model" ]; then
+              echo "OPENAI_MODEL=${model}"
+            fi
+            if [ "$provider" = "gemini" ] && [ -n "$model" ]; then
+              echo "GEMINI_MODEL=${model}"
+            fi
+          } >> "$GITHUB_ENV"
+
+      - name: Start Ollama for manual LLM run
+        if: ${{ inputs.llm_provider == 'ollama' && inputs.task != '' && inputs.tool == '' }}
+        env:
+          INPUT_LLM_MODEL: ${{ inputs.llm_model }}
+        run: |
+          curl -fsSL https://ollama.com/install.sh | sh
+          ollama serve > ollama.log 2>&1 &
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:11434/api/tags >/dev/null; then
+              break
+            fi
+            sleep 2
+          done
+          model="$INPUT_LLM_MODEL"
+          if [ -z "$model" ]; then
+            model="qwen2.5:1.5b"
+          fi
+          ollama pull "$model"
+          echo "OLLAMA_MODEL=$model" >> "$GITHUB_ENV"
+
+      - name: Validate cloud provider secrets
+        if: ${{ inputs.task != '' && inputs.tool == '' && (inputs.llm_provider == 'openai' || inputs.llm_provider == 'gemini') }}
+        env:
+          INPUT_LLM_PROVIDER: ${{ inputs.llm_provider }}
+        run: |
+          if [ "$INPUT_LLM_PROVIDER" = "openai" ] && [ -z "$OPENAI_API_KEY" ]; then
+            echo "OPENAI_API_KEY repository secret is not set. Add it or choose llm_provider=ollama."
+            exit 1
+          fi
+          if [ "$INPUT_LLM_PROVIDER" = "gemini" ] && [ -z "$GEMINI_API_KEY$GOOGLE_API_KEY" ]; then
+            echo "GEMINI_API_KEY or GOOGLE_API_KEY repository secret is not set. Add one or choose llm_provider=ollama."
+            exit 1
+          fi
+
       - name: Run explicit tool when provided
         if: ${{ inputs.tool != '' }}
+        env:
+          INPUT_TOOL: ${{ inputs.tool }}
+          INPUT_TOOL_ARG: ${{ inputs.tool_arg }}
         run: |
-          if [ -n "${{ inputs.tool_arg }}" ]; then
-            python -m adaptive_agent --json --tool "${{ inputs.tool }}" --arg "${{ inputs.tool_arg }}"
+          if [ -n "$INPUT_TOOL_ARG" ]; then
+            python -m adaptive_agent --json --tool "$INPUT_TOOL" --arg "$INPUT_TOOL_ARG"
           else
-            python -m adaptive_agent --json --tool "${{ inputs.tool }}"
+            python -m adaptive_agent --json --tool "$INPUT_TOOL"
           fi
 
       - name: Run natural language task when provided
         if: ${{ inputs.task != '' && inputs.tool == '' }}
-        run: python -m adaptive_agent --json "${{ inputs.task }}"
+        env:
+          INPUT_TASK: ${{ inputs.task }}
+        run: python -m adaptive_agent --json "$INPUT_TASK"
 
       - name: Show usage when no input provided
         if: ${{ inputs.task == '' && inputs.tool == '' }}

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -41,12 +41,9 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest
 
       - name: Run unit tests
-        run: |
-          python -m unittest discover
-          pytest
+        run: python -m unittest discover
 
       - name: Compile source
         run: python -m compileall adaptive_agent tests

--- a/README.md
+++ b/README.md
@@ -120,7 +120,11 @@ python3 -m adaptive_agent --json --tool list_files --arg path=adaptive_agent
 python3 -m adaptive_agent --tool analyze_requirements
 ```
 
-필요하면 GitHub Actions에서 `Run workflow`로 수동 실행할 수 있다. `task`, `tool`, `tool_arg` 입력을 바꿔 PR 브랜치의 CLI 결과를 원격 로그에서 확인할 수 있다.
+필요하면 GitHub Actions에서 `Run workflow`로 수동 실행할 수 있다. `task`, `tool`, `tool_arg`, `llm_provider`, `llm_model` 입력을 바꿔 PR 브랜치의 CLI 결과를 원격 로그에서 확인할 수 있다.
+
+- `llm_provider=ollama`: workflow가 Ollama를 설치하고 지정 모델을 pull한 뒤 자연어 task를 실행한다.
+- `llm_provider=openai`: repository secret `OPENAI_API_KEY`가 있을 때 실행한다.
+- `llm_provider=gemini`: repository secret `GEMINI_API_KEY` 또는 `GOOGLE_API_KEY`가 있을 때 실행한다.
 
 ## Codespace CLI 검증 체크리스트
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,21 @@ python3 -m unittest discover
 python3 -m compileall adaptive_agent tests
 ```
 
+## PR 검증 파이프라인
+
+GitHub Actions의 `PR Validation` 워크플로는 pull request와 `main` push에서 다음을 실행한다.
+
+```bash
+python3 -m unittest discover
+python3 -m compileall adaptive_agent tests
+python3 -m adaptive_agent --list-tools
+python3 -m adaptive_agent --json --tool echo --arg task="hello from ci"
+python3 -m adaptive_agent --json --tool list_files --arg path=adaptive_agent
+python3 -m adaptive_agent --tool analyze_requirements
+```
+
+필요하면 GitHub Actions에서 `Run workflow`로 수동 실행할 수 있다. `task`, `tool`, `tool_args` 입력을 바꿔 PR 브랜치의 CLI 결과를 원격 로그에서 확인할 수 있다.
+
 ## Codespace CLI 검증 체크리스트
 
 LLM 없이 검증:

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ python3 -m adaptive_agent --json --tool list_files --arg path=adaptive_agent
 python3 -m adaptive_agent --tool analyze_requirements
 ```
 
-필요하면 GitHub Actions에서 `Run workflow`로 수동 실행할 수 있다. `task`, `tool`, `tool_args` 입력을 바꿔 PR 브랜치의 CLI 결과를 원격 로그에서 확인할 수 있다.
+필요하면 GitHub Actions에서 `Run workflow`로 수동 실행할 수 있다. `task`, `tool`, `tool_arg` 입력을 바꿔 PR 브랜치의 CLI 결과를 원격 로그에서 확인할 수 있다.
 
 ## Codespace CLI 검증 체크리스트
 

--- a/README.md
+++ b/README.md
@@ -120,11 +120,22 @@ python3 -m adaptive_agent --json --tool list_files --arg path=adaptive_agent
 python3 -m adaptive_agent --tool analyze_requirements
 ```
 
-필요하면 GitHub Actions에서 `Run workflow`로 수동 실행할 수 있다. `task`, `tool`, `tool_arg`, `llm_provider`, `llm_model` 입력을 바꿔 PR 브랜치의 CLI 결과를 원격 로그에서 확인할 수 있다.
+필요하면 GitHub Actions에서 `Run workflow`로 수동 실행할 수 있다. `task`, `tool`, `tool_arg`, `llm_provider`, `llm_model` 입력을 바꿔 PR 브랜치의 CLI 결과를 원격 로그와 Actions Summary에서 확인할 수 있다.
 
 - `llm_provider=ollama`: workflow가 Ollama를 설치하고 지정 모델을 pull한 뒤 자연어 task를 실행한다.
 - `llm_provider=openai`: repository secret `OPENAI_API_KEY`가 있을 때 실행한다.
 - `llm_provider=gemini`: repository secret `GEMINI_API_KEY` 또는 `GOOGLE_API_KEY`가 있을 때 실행한다.
+
+수동 실행 예:
+
+| 목적 | 입력 |
+| --- | --- |
+| 내장 툴 원격 확인 | `tool=echo`, `tool_arg=task=hello` |
+| Ollama 자연어 실행 | `llm_provider=ollama`, `llm_model=qwen2.5:1.5b`, `task=AdaptiveAgent를 한 문장으로 설명해줘` |
+| OpenAI 자연어 실행 | `llm_provider=openai`, `llm_model=gpt-5-nano`, `task=등록된 툴 목록을 요약해줘` |
+| Gemini 자연어 실행 | `llm_provider=gemini`, `llm_model=gemini-2.5-flash-lite`, `task=다음 구현 단계를 요약해줘` |
+
+OpenAI/Gemini를 사용할 때는 GitHub 저장소 Settings -> Secrets and variables -> Actions에 실제 API key를 repository secret으로 추가해야 한다. placeholder key는 클라이언트 초기화 단계에서 거부된다.
 
 ## Codespace CLI 검증 체크리스트
 

--- a/adaptive_agent/agent.py
+++ b/adaptive_agent/agent.py
@@ -25,6 +25,9 @@ class AgentResponse:
     events: list[AgentEvent] = field(default_factory=list)
 
 
+_VALID_PLAN_ACTIONS = {"tool", "respond"}
+
+
 class AdaptiveAgent:
     """자연어 작업을 분석하고 필요한 툴을 실행하는 에이전트 골격."""
 
@@ -63,6 +66,9 @@ class AdaptiveAgent:
         state.history.append(Message(role="user", content=task))
         plan = self._plan_with_llm(task)
         state.step_count += 1
+        validation_error = plan.pop("_validation_error", None)
+        if validation_error:
+            state.record_event("plan_validation_failed", reason=validation_error)
         state.record_event("task_analyzed", action=plan.get("action", "respond"))
         if plan.get("action") == "tool":
             tool_name = str(plan.get("tool_name") or "")
@@ -120,9 +126,52 @@ class AdaptiveAgent:
         except json.JSONDecodeError:
             return {"action": "respond", "response": response}
 
+        return self._normalize_plan(parsed, fallback_response=response)
+
+    def _normalize_plan(self, parsed: object, *, fallback_response: str) -> dict[str, Any]:
+        """LLM 계획 JSON을 Agent가 실행 가능한 최소 계약으로 정규화합니다."""
+
         if not isinstance(parsed, dict):
+            return {
+                "action": "respond",
+                "response": fallback_response,
+                "_validation_error": "plan_not_object",
+            }
+
+        raw_action = parsed.get("action")
+        if raw_action not in _VALID_PLAN_ACTIONS:
+            return {
+                "action": "respond",
+                "response": str(parsed.get("response") or fallback_response),
+                "_validation_error": "unsupported_action",
+            }
+
+        if raw_action == "respond":
+            response = parsed.get("response")
+            if not isinstance(response, str):
+                return {
+                    "action": "respond",
+                    "response": fallback_response,
+                    "_validation_error": "invalid_response",
+                }
             return {"action": "respond", "response": response}
-        return parsed
+
+        tool_name = parsed.get("tool_name")
+        if not isinstance(tool_name, str) or tool_name == "":
+            return {
+                "action": "respond",
+                "response": "LLM 계획에 tool_name이 없어 툴을 실행하지 않았습니다.",
+                "_validation_error": "invalid_tool_name",
+            }
+
+        arguments = parsed.get("arguments", {})
+        if not isinstance(arguments, dict):
+            return {
+                "action": "respond",
+                "response": "툴 실행 인자가 객체가 아니어서 실행하지 않았습니다.",
+                "_validation_error": "invalid_tool_arguments",
+            }
+        return {"action": "tool", "tool_name": tool_name, "arguments": arguments}
 
     def _build_prompt(self, task: str) -> str:
         """LLM에 전달할 기본 지시문을 구성합니다."""

--- a/adaptive_agent/agent.py
+++ b/adaptive_agent/agent.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any
 
 from adaptive_agent.config import AgentConfig
 from adaptive_agent.llms.base import LLMClient
 from adaptive_agent.llms.factory import create_llm_client
+from adaptive_agent.state import AgentEvent, AgentState, Message, ToolSchema
 from adaptive_agent.tools.executor import ToolExecutor
 from adaptive_agent.tools.registry import ToolRegistry, create_default_registry
 
@@ -21,6 +22,7 @@ class AgentResponse:
     output: Any
     tool_name: str | None = None
     action: str = "respond"
+    events: list[AgentEvent] = field(default_factory=list)
 
 
 class AdaptiveAgent:
@@ -45,31 +47,64 @@ class AdaptiveAgent:
 
     def run(self, task: str) -> AgentResponse:
         """사용자 원문 task를 LLM 계획에 따라 수행합니다."""
-        if task == "":
-            return AgentResponse(task=task, output="작업 내용을 입력해 주세요.", action="input_required")
+        state = self._create_state()
+        state.record_event("task_received", task=task)
 
+        if task == "":
+            state.record_event("clarification_requested", reason="empty_task")
+            state.record_event("final_response_created", action="input_required")
+            return AgentResponse(
+                task=task,
+                output="작업 내용을 입력해 주세요.",
+                action="input_required",
+                events=state.events,
+            )
+
+        state.history.append(Message(role="user", content=task))
         plan = self._plan_with_llm(task)
+        state.step_count += 1
+        state.record_event("task_analyzed", action=plan.get("action", "respond"))
         if plan.get("action") == "tool":
             tool_name = str(plan.get("tool_name") or "")
             arguments = plan.get("arguments")
             if not isinstance(arguments, dict):
                 arguments = {}
+            state.record_event("tool_execution_requested", tool_name=tool_name)
             result = self.run_tool(tool_name, arguments)
+            state.record_event("tool_executed", tool_name=tool_name, success=result.success)
+            state.record_event(
+                "tool_result_observed",
+                tool_name=tool_name,
+                success=result.success,
+                has_error=result.error is not None,
+            )
             if result.success:
+                state.record_event("final_response_created", action="tool")
                 return AgentResponse(
                     task=task,
                     output=result.output,
                     tool_name=tool_name,
                     action="tool",
+                    events=state.events,
                 )
+            state.failure_count += 1
+            state.record_event("failure_classified", reason="tool_execution_error")
+            state.record_event("final_response_created", action="tool_error")
             return AgentResponse(
                 task=task,
                 output=f"툴 실행 실패: {result.error}",
                 tool_name=tool_name,
                 action="tool_error",
+                events=state.events,
             )
 
-        return AgentResponse(task=task, output=plan.get("response", ""), action="llm")
+        state.record_event("final_response_created", action="llm")
+        return AgentResponse(
+            task=task,
+            output=plan.get("response", ""),
+            action="llm",
+            events=state.events,
+        )
 
     def run_tool(self, tool_name: str, arguments: dict[str, Any]):
         """명시적으로 지정된 툴을 실행합니다. 자연어 매칭을 수행하지 않습니다."""
@@ -108,4 +143,20 @@ class AdaptiveAgent:
             '{"action":"respond","response":"<answer>"}\n'
             f"Available tools: {json.dumps(tools, ensure_ascii=False)}\n"
             f"Original user task: {task}"
+        )
+
+    def _create_state(self) -> AgentState:
+        """현재 registry를 반영한 실행 상태를 만듭니다."""
+
+        return AgentState(
+            available_tools=[
+                ToolSchema(
+                    name=tool.name,
+                    description=tool.description,
+                    safety_level=tool.safety_level,
+                    source="builtin",
+                    validation_status="passed",
+                )
+                for tool in self.registry.list()
+            ]
         )

--- a/adaptive_agent/cli.py
+++ b/adaptive_agent/cli.py
@@ -134,6 +134,14 @@ def _result_to_dict(result, tool_name: str | None = None) -> dict[str, object]:
             "output": result.output,
             "tool_name": result.tool_name,
             "action": result.action,
+            "events": [
+                {
+                    "name": event.name,
+                    "details": event.details,
+                    "created_at": event.created_at,
+                }
+                for event in getattr(result, "events", [])
+            ],
         }
 
     return {

--- a/adaptive_agent/llms/base.py
+++ b/adaptive_agent/llms/base.py
@@ -10,3 +10,6 @@ class LLMClient(Protocol):
 
     def generate(self, prompt: str) -> str:
         """프롬프트를 전송하고 텍스트 응답을 반환합니다."""
+
+    def complete(self, prompt: str) -> str:
+        """Agent core에서 사용하는 completion 호환 메서드입니다."""

--- a/adaptive_agent/llms/factory.py
+++ b/adaptive_agent/llms/factory.py
@@ -11,7 +11,7 @@ def create_llm_client(config: AgentConfig, provider: str | None = None) -> LLMCl
     """설정에 맞는 LLM 클라이언트를 반환합니다."""
     selected_provider = (provider or config.llm_provider).lower()
     if selected_provider == "ollama":
-        return OllamaClient(model=config.ollama_model)
+        return OllamaClient(model=config.ollama_model, host=config.ollama_host)
     if selected_provider == "openai":
         from adaptive_agent.llms.openai_client import OpenAIClient
 

--- a/adaptive_agent/llms/gemini_client.py
+++ b/adaptive_agent/llms/gemini_client.py
@@ -41,6 +41,11 @@ class GeminiClient:
         self._model = model
         self._api_key = validate_gemini_api_key(_resolve_api_key(api_key))
 
+    def complete(self, prompt: str) -> str:
+        """에이전트 코어가 호출하는 표준 LLM completion 메서드입니다."""
+
+        return self.generate(prompt)
+
     def generate(self, prompt: str) -> str:
         from google import genai
 

--- a/adaptive_agent/llms/ollama.py
+++ b/adaptive_agent/llms/ollama.py
@@ -8,13 +8,15 @@ from adaptive_agent.llms.base import LLMClient
 class OllamaClient:
     """로컬 Ollama 모델을 사용하는 LLM 클라이언트."""
 
-    def __init__(self, model: str) -> None:
+    def __init__(self, model: str, *, host: str | None = None) -> None:
         self.model = model
+        self.host = host
 
     def generate(self, prompt: str) -> str:
         import ollama
 
-        response = ollama.chat(
+        client = ollama.Client(host=self.host) if self.host else ollama.Client()
+        response = client.chat(
             model=self.model,
             messages=[{"role": "user", "content": prompt}],
         )
@@ -26,5 +28,5 @@ class OllamaClient:
         return self.generate(prompt)
 
 
-def create_ollama_client(model: str) -> LLMClient:
-    return OllamaClient(model=model)
+def create_ollama_client(model: str, *, host: str | None = None) -> LLMClient:
+    return OllamaClient(model=model, host=host)

--- a/adaptive_agent/llms/ollama.py
+++ b/adaptive_agent/llms/ollama.py
@@ -20,6 +20,11 @@ class OllamaClient:
         )
         return str(response["message"]["content"])
 
+    def complete(self, prompt: str) -> str:
+        """Agent core가 사용하는 표준 completion 인터페이스입니다."""
+
+        return self.generate(prompt)
+
 
 def create_ollama_client(model: str) -> LLMClient:
     return OllamaClient(model=model)

--- a/adaptive_agent/llms/openai_client.py
+++ b/adaptive_agent/llms/openai_client.py
@@ -86,6 +86,11 @@ class OpenAIClient:
                 raise ValueError(msg) from e
             raise
 
+    def complete(self, prompt: str) -> str:
+        """Agent core가 사용하는 표준 completion 인터페이스입니다."""
+
+        return self.generate(prompt)
+
 
 def create_openai_client(model: str, *, api_key: str | None = None) -> LLMClient:
     return OpenAIClient(model=model, api_key=api_key)

--- a/adaptive_agent/state.py
+++ b/adaptive_agent/state.py
@@ -1,0 +1,63 @@
+"""Agent state and observable execution events."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any, Literal
+from uuid import uuid4
+
+
+MessageRole = Literal["system", "user", "assistant", "tool"]
+
+
+@dataclass(frozen=True)
+class Message:
+    """LLM 대화와 툴 관찰 결과를 보존하는 단일 메시지입니다."""
+
+    role: MessageRole
+    content: str
+    tool_call_id: str | None = None
+
+
+@dataclass(frozen=True)
+class ToolSchema:
+    """LLM과 실행기가 공유하는 툴 입력 계약입니다."""
+
+    name: str
+    description: str
+    parameters: dict[str, Any] = field(default_factory=dict)
+    returns: dict[str, Any] = field(default_factory=dict)
+    safety_level: str = "low"
+    source: str = "builtin"
+    validation_status: str = "unverified"
+
+
+@dataclass(frozen=True)
+class AgentEvent:
+    """PR/CLI/테스트에서 확인할 수 있는 실행 이벤트입니다."""
+
+    name: str
+    details: dict[str, Any] = field(default_factory=dict)
+    created_at: str = field(
+        default_factory=lambda: datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    )
+
+
+@dataclass
+class AgentState:
+    """한 번의 Agent 실행 세션에서 유지할 상태입니다."""
+
+    session_id: str = field(default_factory=lambda: uuid4().hex)
+    history: list[Message] = field(default_factory=list)
+    events: list[AgentEvent] = field(default_factory=list)
+    step_count: int = 0
+    available_tools: list[ToolSchema] = field(default_factory=list)
+    candidate_tools: list[ToolSchema] = field(default_factory=list)
+    failure_count: int = 0
+    summary: str = ""
+
+    def record_event(self, name: str, **details: Any) -> None:
+        """관찰 가능한 실행 이벤트를 순서대로 기록합니다."""
+
+        self.events.append(AgentEvent(name=name, details=details))

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -75,6 +75,36 @@ class AdaptiveAgentTest(unittest.TestCase):
             ],
         )
 
+    def test_tool_plan_without_tool_name_is_rejected(self) -> None:
+        llm = StubLLM('{"action":"tool","arguments":{"task":"원문 그대로"}}')
+        agent = AdaptiveAgent(config=AgentConfig(), llm_client=llm)
+
+        result = agent.run("사용자 원문")
+
+        self.assertEqual(result.action, "llm")
+        self.assertEqual(result.output, "LLM 계획에 tool_name이 없어 툴을 실행하지 않았습니다.")
+        self.assertIn("plan_validation_failed", [event.name for event in result.events])
+
+    def test_unknown_plan_action_falls_back_to_response(self) -> None:
+        llm = StubLLM('{"action":"unexpected","response":"대체 응답"}')
+        agent = AdaptiveAgent(config=AgentConfig(), llm_client=llm)
+
+        result = agent.run("사용자 원문")
+
+        self.assertEqual(result.action, "llm")
+        self.assertEqual(result.output, "대체 응답")
+        self.assertIn("plan_validation_failed", [event.name for event in result.events])
+
+    def test_tool_plan_arguments_must_be_object(self) -> None:
+        llm = StubLLM('{"action":"tool","tool_name":"echo","arguments":["bad"]}')
+        agent = AdaptiveAgent(config=AgentConfig(), llm_client=llm)
+
+        result = agent.run("사용자 원문")
+
+        self.assertEqual(result.output, "툴 실행 인자가 객체가 아니어서 실행하지 않았습니다.")
+        self.assertEqual(result.action, "llm")
+        self.assertIn("plan_validation_failed", [event.name for event in result.events])
+
     def test_tool_error_records_failure_event(self) -> None:
         llm = StubLLM('{"action":"tool","tool_name":"missing_tool","arguments":{}}')
         agent = AdaptiveAgent(config=AgentConfig(), llm_client=llm)

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -28,6 +28,11 @@ class AdaptiveAgentTest(unittest.TestCase):
 
         self.assertEqual(result.output, "작업 내용을 입력해 주세요.")
         self.assertIsNone(result.tool_name)
+        self.assertEqual([event.name for event in result.events], [
+            "task_received",
+            "clarification_requested",
+            "final_response_created",
+        ])
 
     def test_whitespace_task_is_preserved_for_llm(self) -> None:
         llm = StubLLM()
@@ -58,6 +63,28 @@ class AdaptiveAgentTest(unittest.TestCase):
         self.assertEqual(result.output, "원문 그대로")
         self.assertEqual(result.tool_name, "echo")
         self.assertEqual(result.action, "tool")
+        self.assertEqual(
+            [event.name for event in result.events],
+            [
+                "task_received",
+                "task_analyzed",
+                "tool_execution_requested",
+                "tool_executed",
+                "tool_result_observed",
+                "final_response_created",
+            ],
+        )
+
+    def test_tool_error_records_failure_event(self) -> None:
+        llm = StubLLM('{"action":"tool","tool_name":"missing_tool","arguments":{}}')
+        agent = AdaptiveAgent(config=AgentConfig(), llm_client=llm)
+
+        result = agent.run("없는 툴 실행")
+
+        self.assertEqual(result.action, "tool_error")
+        self.assertEqual(result.tool_name, "missing_tool")
+        self.assertIn("툴 실행 실패", result.output)
+        self.assertIn("failure_classified", [event.name for event in result.events])
 
     def test_requirements_analysis_tool_returns_breakdown(self) -> None:
         agent = AdaptiveAgent(config=AgentConfig(), llm_client=StubLLM())

--- a/tests/test_llm_factory.py
+++ b/tests/test_llm_factory.py
@@ -1,0 +1,54 @@
+"""LLM factory routing tests."""
+
+from __future__ import annotations
+
+import unittest
+from unittest.mock import Mock, patch
+
+from adaptive_agent.config import AgentConfig
+from adaptive_agent.llms.factory import create_llm_client
+from adaptive_agent.llms.ollama import OllamaClient
+
+
+class LLMFactoryTest(unittest.TestCase):
+    def test_ollama_client_receives_model_and_host(self) -> None:
+        config = AgentConfig(ollama_model="qwen-test", ollama_host="http://localhost:11434")
+
+        client = create_llm_client(config, provider="ollama")
+
+        self.assertEqual(client.model, "qwen-test")
+        self.assertEqual(client.host, "http://localhost:11434")
+
+    def test_openai_provider_uses_configured_model(self) -> None:
+        config = AgentConfig(openai_model="gpt-5-nano")
+
+        with patch("adaptive_agent.llms.openai_client.OpenAIClient") as client_class:
+            create_llm_client(config, provider="openai")
+
+        client_class.assert_called_once_with(model="gpt-5-nano")
+
+    def test_gemini_provider_uses_configured_model(self) -> None:
+        config = AgentConfig(gemini_model="gemini-2.5-flash-lite")
+
+        with patch("adaptive_agent.llms.gemini_client.GeminiClient") as client_class:
+            create_llm_client(config, provider="gemini")
+
+        client_class.assert_called_once_with(model="gemini-2.5-flash-lite")
+
+    def test_ollama_client_uses_configured_host(self) -> None:
+        ollama_client = Mock()
+        ollama_client.chat.return_value = {"message": {"content": "ok"}}
+
+        with patch("ollama.Client", return_value=ollama_client) as client_class:
+            result = OllamaClient(model="qwen-test", host="http://ollama.test:11434").complete("hello")
+
+        self.assertEqual(result, "ok")
+        client_class.assert_called_once_with(host="http://ollama.test:11434")
+        ollama_client.chat.assert_called_once_with(
+            model="qwen-test",
+            messages=[{"role": "user", "content": "hello"}],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_llm_factory.py
+++ b/tests/test_llm_factory.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import sys
+from types import SimpleNamespace
 import unittest
 from unittest.mock import Mock, patch
 
@@ -38,12 +40,13 @@ class LLMFactoryTest(unittest.TestCase):
     def test_ollama_client_uses_configured_host(self) -> None:
         ollama_client = Mock()
         ollama_client.chat.return_value = {"message": {"content": "ok"}}
+        ollama_module = SimpleNamespace(Client=Mock(return_value=ollama_client))
 
-        with patch("ollama.Client", return_value=ollama_client) as client_class:
+        with patch.dict(sys.modules, {"ollama": ollama_module}):
             result = OllamaClient(model="qwen-test", host="http://ollama.test:11434").complete("hello")
 
         self.assertEqual(result, "ok")
-        client_class.assert_called_once_with(host="http://ollama.test:11434")
+        ollama_module.Client.assert_called_once_with(host="http://ollama.test:11434")
         ollama_client.chat.assert_called_once_with(
             model="qwen-test",
             messages=[{"role": "user", "content": "hello"}],

--- a/tests/test_openai_routing.py
+++ b/tests/test_openai_routing.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-import pytest
+import unittest
 
 from adaptive_agent.llms.openai_client import (
     should_use_openai_responses_api,
@@ -10,18 +10,21 @@ from adaptive_agent.llms.openai_client import (
 )
 
 
-def test_should_use_openai_responses_api_gpt5_family() -> None:
-    assert should_use_openai_responses_api("gpt-5-nano") is True
-    assert should_use_openai_responses_api("gpt-5-nano-2025-08-07") is True
-    assert should_use_openai_responses_api("gpt-4o-mini") is False
-    assert should_use_openai_responses_api("gpt-4.1-nano") is False
+class OpenAIRoutingTest(unittest.TestCase):
+    def test_should_use_openai_responses_api_gpt5_family(self) -> None:
+        self.assertTrue(should_use_openai_responses_api("gpt-5-nano"))
+        self.assertTrue(should_use_openai_responses_api("gpt-5-nano-2025-08-07"))
+        self.assertFalse(should_use_openai_responses_api("gpt-4o-mini"))
+        self.assertFalse(should_use_openai_responses_api("gpt-4.1-nano"))
+
+    def test_validate_openai_api_key_rejects_placeholder(self) -> None:
+        with self.assertRaisesRegex(ValueError, "예시"):
+            validate_openai_api_key("your_openai_key_here")
+
+    def test_validate_openai_api_key_accepts_sk_prefix(self) -> None:
+        key = "sk-" + "a" * 45
+        self.assertEqual(validate_openai_api_key(key), key)
 
 
-def test_validate_openai_api_key_rejects_placeholder() -> None:
-    with pytest.raises(ValueError, match="예시"):
-        validate_openai_api_key("your_openai_key_here")
-
-
-def test_validate_openai_api_key_accepts_sk_prefix() -> None:
-    key = "sk-" + "a" * 45
-    assert validate_openai_api_key(key) == key
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 요약

main에 아직 반영되지 않은 Agent 이벤트 로그, LLM 연결 안정화, PR/수동 실행 workflow를 추가합니다. 이 PR이 main에 머지되어야 Actions 탭에서 `Run workflow`로 manual CLI/LLM 실행이 활성화됩니다.

## 관련 이슈

없음

## 변경 사항

- `adaptive_agent/state.py` 추가
  - `Message`, `ToolSchema`, `AgentEvent`, `AgentState` dataclass 정의
- `AdaptiveAgent` 실행 이벤트 기록 추가
  - `task_received`, `task_analyzed`, `tool_executed`, `tool_result_observed`, `failure_classified`, `final_response_created` 등
- LLM plan JSON 검증/정규화 추가
  - 지원하지 않는 action, 누락된 `tool_name`, 잘못된 `arguments`, 잘못된 `response`를 안전하게 respond 경로로 전환
  - `plan_validation_failed` 이벤트로 검증 실패 이유 기록
- CLI JSON 출력에 agent event 로그 포함
- LLM 연결 안정화
  - provider 구현에 `complete()` 호환 메서드 추가
  - `OLLAMA_HOST` 설정을 `ollama.Client(host=...)` 호출에 반영
  - OpenAI/Gemini/Ollama factory routing 테스트 추가
- `.github/workflows/pr-validation.yml` 추가
  - PR/push 자동 검증
  - `workflow_dispatch` 수동 실행 지원
  - `llm_provider`, `llm_model`, `task`, `tool`, `tool_arg` 입력 지원
  - manual run 결과를 GitHub Actions Step Summary에 요약
- README에 수동 원격 CLI/LLM 테스트 방법 및 secret 안내 추가

## 테스트

- [x] `python3 -m unittest discover` — 23 tests OK
- [x] `python3 -m compileall adaptive_agent tests`
- [x] `python3 -m adaptive_agent --json --tool echo --arg task="hello from ci"`
- [x] `python3 -m adaptive_agent --json --tool analyze_requirements`
- [x] 브랜치 push 기준 GitHub Actions `PR Validation` 성공

## 스크린샷 / 로그 (선택)

이 PR이 main에 머지된 뒤 Actions 탭에서 `PR Validation` -> `Run workflow`를 사용할 수 있습니다.

예시 입력:
- OpenAI: `llm_provider=openai`, `llm_model=gpt-5-nano`, `task=OPENAI_SECRET_CONNECTION_OK 라고만 답해줘`
- Tool: `tool=echo`, `tool_arg=task=hello`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d82c8f70-fc2b-464c-8025-f121001e64cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d82c8f70-fc2b-464c-8025-f121001e64cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

