### PR TITLE
fix(llm): surface provider errors in manual checks

### DIFF
--- a/.github/workflows/manual-llm-check.yml
+++ b/.github/workflows/manual-llm-check.yml
@@ -1,0 +1,130 @@
+name: Manual LLM Check
+
+on:
+  workflow_dispatch:
+    inputs:
+      llm_provider:
+        description: "LLM provider: openai, gemini, or ollama"
+        required: true
+        default: "openai"
+        type: choice
+        options:
+          - openai
+          - gemini
+          - ollama
+      llm_model:
+        description: "Model name. Recommended OpenAI default: gpt-5-nano"
+        required: false
+        default: "gpt-5-nano"
+      task:
+        description: "Natural language task to send to the selected LLM"
+        required: false
+        default: "연결 테스트입니다. 최종 응답으로 CONNECTION_OK 라고만 답해줘."
+
+jobs:
+  manual-llm-check:
+    name: Manual LLM connection check
+    runs-on: ubuntu-latest
+    env:
+      OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
+      GOOGLE_API_KEY: ${{ secrets.GOOGLE_API_KEY }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Configure selected provider
+        env:
+          INPUT_LLM_PROVIDER: ${{ inputs.llm_provider }}
+          INPUT_LLM_MODEL: ${{ inputs.llm_model }}
+        run: |
+          provider="$INPUT_LLM_PROVIDER"
+          model="$INPUT_LLM_MODEL"
+          {
+            echo "ADAPTIVE_AGENT_LLM=$provider"
+            if [ "$provider" = "openai" ]; then
+              echo "OPENAI_MODEL=${model:-gpt-5-nano}"
+            fi
+            if [ "$provider" = "gemini" ]; then
+              echo "GEMINI_MODEL=${model:-gemini-2.5-flash-lite}"
+            fi
+            if [ "$provider" = "ollama" ]; then
+              echo "OLLAMA_MODEL=${model:-qwen2.5:1.5b}"
+            fi
+          } >> "$GITHUB_ENV"
+
+      - name: Start Ollama when selected
+        if: ${{ inputs.llm_provider == 'ollama' }}
+        env:
+          INPUT_LLM_MODEL: ${{ inputs.llm_model }}
+        run: |
+          curl -fsSL https://ollama.com/install.sh | sh
+          ollama serve > ollama.log 2>&1 &
+          for i in $(seq 1 30); do
+            if curl -fsS http://127.0.0.1:11434/api/tags >/dev/null; then
+              break
+            fi
+            sleep 2
+          done
+          model="$INPUT_LLM_MODEL"
+          if [ -z "$model" ]; then
+            model="qwen2.5:1.5b"
+          fi
+          ollama pull "$model"
+          echo "OLLAMA_MODEL=$model" >> "$GITHUB_ENV"
+
+      - name: Validate cloud secrets
+        env:
+          INPUT_LLM_PROVIDER: ${{ inputs.llm_provider }}
+        run: |
+          if [ "$INPUT_LLM_PROVIDER" = "openai" ] && [ -z "$OPENAI_API_KEY" ]; then
+            echo "OPENAI_API_KEY repository secret is not set."
+            exit 1
+          fi
+          if [ "$INPUT_LLM_PROVIDER" = "gemini" ] && [ -z "$GEMINI_API_KEY$GOOGLE_API_KEY" ]; then
+            echo "GEMINI_API_KEY or GOOGLE_API_KEY repository secret is not set."
+            exit 1
+          fi
+
+      - name: Run LLM task
+        env:
+          INPUT_LLM_PROVIDER: ${{ inputs.llm_provider }}
+          INPUT_LLM_MODEL: ${{ inputs.llm_model }}
+          INPUT_TASK: ${{ inputs.task }}
+        run: |
+          set -o pipefail
+          {
+            echo "## Manual LLM Check"
+            echo ""
+            echo "- Provider: \`$INPUT_LLM_PROVIDER\`"
+            echo "- Requested model: \`${INPUT_LLM_MODEL:-default}\`"
+            echo "- Effective OpenAI model: \`${OPENAI_MODEL:-n/a}\`"
+            echo "- Effective Gemini model: \`${GEMINI_MODEL:-n/a}\`"
+            echo "- Effective Ollama model: \`${OLLAMA_MODEL:-n/a}\`"
+            echo "- Task: \`$INPUT_TASK\`"
+            echo ""
+            echo "\`\`\`json"
+          } >> "$GITHUB_STEP_SUMMARY"
+          python -m adaptive_agent --json "$INPUT_TASK" | tee result.json | tee -a "$GITHUB_STEP_SUMMARY"
+          echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+          python - <<'PY'
+          import json
+          import sys
+
+          with open("result.json", encoding="utf-8") as handle:
+              result = json.load(handle)
+          if result.get("action") == "llm_error":
+              print(result.get("output", "LLM check failed"))
+              sys.exit(1)
+          PY

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -148,6 +148,7 @@ jobs:
           INPUT_TOOL: ${{ inputs.tool }}
           INPUT_TOOL_ARG: ${{ inputs.tool_arg }}
         run: |
+          set -o pipefail
           echo "## AdaptiveAgent manual CLI result" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- Mode: explicit tool" >> "$GITHUB_STEP_SUMMARY"
@@ -171,6 +172,7 @@ jobs:
           INPUT_LLM_MODEL: ${{ inputs.llm_model }}
           INPUT_TASK: ${{ inputs.task }}
         run: |
+          set -o pipefail
           echo "## AdaptiveAgent manual LLM result" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "- Provider: \`$INPUT_LLM_PROVIDER\`" >> "$GITHUB_STEP_SUMMARY"
@@ -184,8 +186,16 @@ jobs:
           echo "- Task: \`$INPUT_TASK\`" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
           echo "\`\`\`json" >> "$GITHUB_STEP_SUMMARY"
-          python -m adaptive_agent --json "$INPUT_TASK" | tee -a "$GITHUB_STEP_SUMMARY"
+          python -m adaptive_agent --json "$INPUT_TASK" | tee adaptive-agent-result.json | tee -a "$GITHUB_STEP_SUMMARY"
           echo "\`\`\`" >> "$GITHUB_STEP_SUMMARY"
+          python - <<'PY'
+          import json
+          from pathlib import Path
+
+          result = json.loads(Path("adaptive-agent-result.json").read_text(encoding="utf-8"))
+          if result.get("action") == "llm_error":
+              raise SystemExit("AdaptiveAgent returned llm_error; see workflow summary for details.")
+          PY
 
       - name: Show usage when no input provided
         if: ${{ inputs.task == '' && inputs.tool == '' }}

--- a/README.md
+++ b/README.md
@@ -135,7 +135,9 @@ python3 -m adaptive_agent --tool analyze_requirements
 | OpenAI 자연어 실행 | `llm_provider=openai`, `llm_model=gpt-5-nano`, `task=등록된 툴 목록을 요약해줘` |
 | Gemini 자연어 실행 | `llm_provider=gemini`, `llm_model=gemini-2.5-flash-lite`, `task=다음 구현 단계를 요약해줘` |
 
-OpenAI/Gemini를 사용할 때는 GitHub 저장소 Settings -> Secrets and variables -> Actions에 실제 API key를 repository secret으로 추가해야 한다. placeholder key는 클라이언트 초기화 단계에서 거부된다.
+OpenAI/Gemini를 사용할 때는 GitHub 저장소 Settings -> Secrets and variables -> Actions에 실제 API key를 repository secret으로 추가해야 한다. placeholder key는 클라이언트 초기화 단계에서 거부된다. OpenAI 모델명은 실제 계정에서 사용 가능한 값을 넣어야 하며, 예를 들어 `gpt-5-nano` 또는 `gpt-4o-mini`처럼 존재하는 모델을 사용한다. 존재하지 않는 모델명(예: 임의의 `gpt-5.2-nano`)은 `model_not_found`로 실패한다.
+
+OpenAI/Gemini/Ollama 연결만 빠르게 확인하고 싶으면 Actions의 **Manual LLM Check** workflow를 사용한다. 이 workflow는 수동 실행 전용이며, 실패해도 traceback 대신 JSON 오류와 Actions Summary를 남긴다.
 
 ## Codespace CLI 검증 체크리스트
 

--- a/adaptive_agent/agent.py
+++ b/adaptive_agent/agent.py
@@ -64,7 +64,18 @@ class AdaptiveAgent:
             )
 
         state.history.append(Message(role="user", content=task))
-        plan = self._plan_with_llm(task)
+        try:
+            plan = self._plan_with_llm(task)
+        except Exception as exc:
+            state.failure_count += 1
+            state.record_event("failure_classified", reason="external_provider_error")
+            state.record_event("final_response_created", action="llm_error")
+            return AgentResponse(
+                task=task,
+                output=f"LLM 호출 실패: {exc}",
+                action="llm_error",
+                events=state.events,
+            )
         state.step_count += 1
         validation_error = plan.pop("_validation_error", None)
         if validation_error:

--- a/adaptive_agent/llms/openai_client.py
+++ b/adaptive_agent/llms/openai_client.py
@@ -41,6 +41,38 @@ def validate_openai_api_key(key: str | None) -> str:
     return k
 
 
+def format_openai_api_error(*, status_code: int | None, message: str, model: str) -> str | None:
+    """OpenAI SDK 오류를 사용자가 바로 조치할 수 있는 메시지로 바꿉니다."""
+
+    if status_code == 401:
+        return (
+            "OpenAI가 API 키를 거부했습니다(401). "
+            ".env의 OPENAI_API_KEY가 유효한 sk- 키인지, 공백·따옴표 오류는 없는지 확인하세요."
+        )
+    if status_code == 400 and "model" in message.lower():
+        return (
+            "OpenAI 모델 요청이 실패했습니다(400). "
+            f"모델명 `{model}`이 현재 계정/API에서 사용 가능한지 확인하세요. "
+            "예: gpt-5-nano 또는 gpt-4o-mini. "
+            f"원본: {message}"
+        )
+    return None
+
+
+def _extract_openai_error_message(exc: Exception) -> str:
+    response = getattr(exc, "response", None)
+    if response is not None:
+        try:
+            payload = response.json()
+        except Exception:
+            payload = {}
+        if isinstance(payload, dict):
+            error = payload.get("error")
+            if isinstance(error, dict):
+                return str(error.get("message") or "")
+    return str(exc)
+
+
 class OpenAIClient:
     """OpenAI `chat.completions` 또는 `responses` 기반 최소 클라이언트."""
 
@@ -78,12 +110,14 @@ class OpenAIClient:
             choice = response.choices[0].message.content
             return (choice if choice is not None else "").strip()
         except APIError as e:
-            if getattr(e, "status_code", None) == 401:
-                msg = (
-                    "OpenAI가 API 키를 거부했습니다(401). "
-                    ".env의 OPENAI_API_KEY가 유효한 sk- 키인지, 공백·따옴표 오류는 없는지 확인하세요."
-                )
-                raise ValueError(msg) from e
+            message = _extract_openai_error_message(e)
+            formatted = format_openai_api_error(
+                status_code=getattr(e, "status_code", None),
+                message=message,
+                model=self._model,
+            )
+            if formatted:
+                raise ValueError(formatted) from e
             raise
 
     def complete(self, prompt: str) -> str:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -20,6 +20,13 @@ class StubLLM:
         return self.response
 
 
+class FailingLLM:
+    """테스트용 실패 LLM 클라이언트."""
+
+    def complete(self, _prompt: str) -> str:
+        raise ValueError("LLM 연결 실패")
+
+
 class AdaptiveAgentTest(unittest.TestCase):
     def test_empty_task_only_rejects_exact_empty_string(self) -> None:
         agent = AdaptiveAgent(config=AgentConfig(), llm_client=StubLLM())
@@ -53,6 +60,15 @@ class AdaptiveAgentTest(unittest.TestCase):
         self.assertEqual(result.output, "LLM 응답")
         self.assertIsNone(result.tool_name)
         self.assertIn("echo 안녕하세요", llm.prompts[0])
+
+    def test_llm_error_returns_structured_response(self) -> None:
+        agent = AdaptiveAgent(config=AgentConfig(), llm_client=FailingLLM())
+
+        result = agent.run("OpenAI 연결 확인")
+
+        self.assertEqual(result.action, "llm_error")
+        self.assertEqual(result.output, "LLM 호출 실패: LLM 연결 실패")
+        self.assertIn("failure_classified", [event.name for event in result.events])
 
     def test_llm_json_plan_executes_tool(self) -> None:
         llm = StubLLM('{"action":"tool","tool_name":"echo","arguments":{"task":"원문 그대로"}}')

--- a/tests/test_openai_client.py
+++ b/tests/test_openai_client.py
@@ -1,0 +1,25 @@
+"""OpenAI client error handling tests."""
+
+from __future__ import annotations
+
+import unittest
+
+from adaptive_agent.llms.openai_client import format_openai_api_error
+
+
+class OpenAIClientTest(unittest.TestCase):
+    def test_model_not_found_error_has_actionable_message(self) -> None:
+        message = format_openai_api_error(
+            status_code=400,
+            model="gpt-5.2-nano",
+            message="The requested model 'gpt-5.2-nano' does not exist.",
+        )
+
+        self.assertIsNotNone(message)
+        self.assertIn("gpt-5.2-nano", message)
+        self.assertIn("gpt-5-nano", message)
+        self.assertIn("gpt-4o-mini", message)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 요약

수동 OpenAI 테스트에서 잘못된 모델명 입력 시 traceback이 노출되고 workflow가 성공처럼 보일 수 있던 문제를 수정합니다. main 브랜치의 기본 CLI/LLM 점검 경로가 더 명확하게 실패를 표시하도록 정리했습니다.

## 관련 이슈

없음

## 변경 사항

- Agent LLM 호출 실패를 구조화된 `llm_error` 응답으로 반환
  - traceback 대신 JSON output과 `failure_classified` 이벤트 제공
- OpenAI API 오류 메시지 개선
  - 401: API key 확인 안내
  - 400 + model 관련 오류: 모델명 확인 안내
  - 예: `gpt-5.2-nano` 같은 존재하지 않는 모델은 `gpt-5-nano`/`gpt-4o-mini` 예시와 함께 안내
- PR Validation manual run 보강
  - `set -o pipefail` 적용
  - `llm_error` 응답이면 workflow 실패 처리
  - Summary에 JSON 결과 유지
- `Manual LLM Check` 전용 workflow 추가
  - OpenAI/Gemini/Ollama 연결 확인 전용
  - Summary에 provider/model/task/result 출력
- README 보강
  - 실제 사용 가능한 OpenAI 모델명 입력 필요 안내
  - Manual LLM Check workflow 안내
- 회귀 테스트 추가
  - LLM provider 실패가 `llm_error`로 반환되는지 확인
  - OpenAI model_not_found 안내 메시지 검증

## 테스트

- [x] `python3 -m unittest discover` — 25 tests OK
- [x] `python3 -m compileall adaptive_agent tests`
- [x] `python3 -m adaptive_agent --json --tool echo --arg task="hello from ci"`
- [x] `python3 -m adaptive_agent --json --tool analyze_requirements`

## 스크린샷 / 로그 (선택)

수동 테스트 실패 원인 확인:

- secret은 정상 주입됨
- 사용 입력 모델: `gpt-5.2-nano`
- OpenAI 응답: `model_not_found`
- 조치: 존재하는 모델명(`gpt-5-nano`, `gpt-4o-mini` 등) 안내 및 workflow 실패 처리 개선
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d82c8f70-fc2b-464c-8025-f121001e64cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d82c8f70-fc2b-464c-8025-f121001e64cf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

