### PR TITLE
test: add AAVS provider validation harness

### DIFF
--- a/.github/workflows/manual-llm-check.yml
+++ b/.github/workflows/manual-llm-check.yml
@@ -59,16 +59,26 @@ jobs:
         run: |
           provider="$INPUT_LLM_PROVIDER"
           model="$INPUT_LLM_MODEL"
+          if [ "$provider" = "ollama" ] && { [ -z "$model" ] || [ "$model" = "gpt-5-nano" ]; }; then
+            model="qwen2.5:1.5b"
+          fi
+          if [ "$provider" = "gemini" ] && { [ -z "$model" ] || [ "$model" = "gpt-5-nano" ]; }; then
+            model="gemini-2.5-flash-lite"
+          fi
+          if [ "$provider" = "openai" ] && [ -z "$model" ]; then
+            model="gpt-5-nano"
+          fi
           {
             echo "ADAPTIVE_AGENT_LLM=$provider"
+            echo "EFFECTIVE_LLM_MODEL=$model"
             if [ "$provider" = "openai" ]; then
-              echo "OPENAI_MODEL=${model:-gpt-5-nano}"
+              echo "OPENAI_MODEL=$model"
             fi
             if [ "$provider" = "gemini" ]; then
-              echo "GEMINI_MODEL=${model:-gemini-2.5-flash-lite}"
+              echo "GEMINI_MODEL=$model"
             fi
             if [ "$provider" = "ollama" ]; then
-              echo "OLLAMA_MODEL=${model:-qwen2.5:1.5b}"
+              echo "OLLAMA_MODEL=$model"
             fi
           } >> "$GITHUB_ENV"
 
@@ -85,8 +95,8 @@ jobs:
             fi
             sleep 2
           done
-          model="$INPUT_LLM_MODEL"
-          if [ -z "$model" ]; then
+          model="${EFFECTIVE_LLM_MODEL:-$INPUT_LLM_MODEL}"
+          if [ -z "$model" ] || [ "$model" = "gpt-5-nano" ]; then
             model="qwen2.5:1.5b"
           fi
           ollama pull "$model"
@@ -116,7 +126,7 @@ jobs:
           mkdir -p "$output_dir"
           python scripts/aavs_validate.py \
             --provider "$INPUT_LLM_PROVIDER" \
-            --model "$INPUT_LLM_MODEL" \
+            --model "${EFFECTIVE_LLM_MODEL:-$INPUT_LLM_MODEL}" \
             --output "$output_dir/records.json" \
             --markdown-output "$output_dir/records.md" \
             --scenario AAVS-001 \
@@ -128,6 +138,7 @@ jobs:
             echo ""
             echo "- Provider: \`$INPUT_LLM_PROVIDER\`"
             echo "- Requested model: \`${INPUT_LLM_MODEL:-default}\`"
+            echo "- Effective model: \`${EFFECTIVE_LLM_MODEL:-default}\`"
             echo "- Output directory: \`$output_dir\`"
             echo ""
             echo "\`\`\`"

--- a/.github/workflows/manual-llm-check.yml
+++ b/.github/workflows/manual-llm-check.yml
@@ -16,6 +16,14 @@ on:
         description: "Model name. Recommended OpenAI default: gpt-5-nano"
         required: false
         default: "gpt-5-nano"
+      validation_suite:
+        description: "Validation suite to run instead of a single task"
+        required: false
+        default: "none"
+        type: choice
+        options:
+          - none
+          - aavs
       task:
         description: "Natural language task to send to the selected LLM"
         required: false
@@ -97,7 +105,45 @@ jobs:
             exit 1
           fi
 
+      - name: Run AAVS validation suite
+        if: ${{ inputs.validation_suite == 'aavs' }}
+        env:
+          INPUT_LLM_PROVIDER: ${{ inputs.llm_provider }}
+          INPUT_LLM_MODEL: ${{ inputs.llm_model }}
+        run: |
+          set -o pipefail
+          output_dir="aavs-results-${INPUT_LLM_PROVIDER}"
+          mkdir -p "$output_dir"
+          python scripts/aavs_validate.py \
+            --provider "$INPUT_LLM_PROVIDER" \
+            --model "$INPUT_LLM_MODEL" \
+            --output "$output_dir/records.json" \
+            --markdown-output "$output_dir/records.md" \
+            --scenario AAVS-001 \
+            --scenario AAVS-003A \
+            --scenario AAVS-003B \
+            --scenario AAVS-006 | tee aavs-validation.log
+          {
+            echo "## AAVS Validation"
+            echo ""
+            echo "- Provider: \`$INPUT_LLM_PROVIDER\`"
+            echo "- Requested model: \`${INPUT_LLM_MODEL:-default}\`"
+            echo "- Output directory: \`$output_dir\`"
+            echo ""
+            echo "\`\`\`"
+            cat aavs-validation.log
+            echo "\`\`\`"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload AAVS validation artifacts
+        if: ${{ inputs.validation_suite == 'aavs' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: aavs-results-${{ inputs.llm_provider }}
+          path: aavs-results-${{ inputs.llm_provider }}/
+
       - name: Run LLM task
+        if: ${{ inputs.validation_suite == 'none' }}
         env:
           INPUT_LLM_PROVIDER: ${{ inputs.llm_provider }}
           INPUT_LLM_MODEL: ${{ inputs.llm_model }}

--- a/README.md
+++ b/README.md
@@ -144,6 +144,17 @@ OpenAI/Gemini를 사용할 때는 GitHub 저장소 Settings -> Secrets and varia
 
 OpenAI/Gemini/Ollama 연결만 빠르게 확인하고 싶으면 Actions의 **Manual LLM Check** workflow를 사용한다. 이 workflow는 수동 실행 전용이며, 실패해도 traceback 대신 JSON 오류와 Actions Summary를 남긴다.
 
+AAVS 시나리오 기반으로 OpenAI 또는 Ollama가 적절한 툴 호출과 구조화 데이터 파싱 코드를 생성하는지 확인하려면 같은 workflow에서 `validation_suite=aavs`를 선택한다. OpenAI는 repository secret `OPENAI_API_KEY`를 사용하고, Ollama는 workflow runner에서 Ollama를 설치한 뒤 선택 모델을 pull한다.
+
+로컬에서 provider가 준비된 경우에는 아래처럼 직접 실행할 수 있다.
+
+```bash
+python scripts/aavs_validate.py --provider openai --model gpt-5-nano --output-dir aavs-results-openai
+python scripts/aavs_validate.py --provider ollama --model qwen2.5:1.5b --output-dir aavs-results-ollama
+```
+
+검증 프롬프트는 영어로 작성되어 있으며, 특정 정답만 맞히도록 유도하지 않고 JSON/CSV 같은 구조화 데이터는 표준 파서를 사용한 실행 가능한 Python 코드로 처리하도록 일반 원칙을 확인한다.
+
 ## Codespace CLI 검증 체크리스트
 
 LLM 없이 검증:

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ python scripts/aavs_validate.py --provider ollama --model qwen2.5:1.5b --output-
 
 검증 프롬프트는 영어로 작성되어 있으며, 특정 정답만 맞히도록 유도하지 않고 JSON/CSV 같은 구조화 데이터는 표준 파서를 사용한 실행 가능한 Python 코드로 처리하도록 일반 원칙을 확인한다.
 
+현재 자동 하네스는 AAVS-001, AAVS-003A/B, AAVS-006을 대상으로 한다. AAVS-002(self-correction), AAVS-004(저장 동의 y/n), AAVS-005(저장 툴 재사용)는 에이전트 루프와 툴 저장 정책이 확장된 뒤 별도 자동 검증으로 추가해야 한다. 또한 현재 Agent는 툴 실행 후 자연어 최종 답변을 다시 합성하지 않고 raw tool output을 반환하므로, 하네스의 `final_response_scope` 필드는 `raw_tool_output`으로 기록된다.
+
 ## Codespace CLI 검증 체크리스트
 
 LLM 없이 검증:

--- a/adaptive_agent/agent.py
+++ b/adaptive_agent/agent.py
@@ -89,6 +89,16 @@ class AdaptiveAgent:
             arguments = plan.get("arguments")
             if not isinstance(arguments, dict):
                 arguments = {}
+            state.record_event(
+                "tool_spec_created",
+                tool_name=tool_name,
+                argument_keys=sorted(str(key) for key in arguments),
+            )
+            code = arguments.get("code")
+            if isinstance(code, str) and code:
+                state.record_event("tool_code_created", tool_name=tool_name, code=code)
+            if tool_name == "ask_human":
+                state.record_event("clarification_requested", reason="llm_requested_human_input")
             state.record_event("tool_execution_requested", tool_name=tool_name)
             result = self.run_tool(tool_name, arguments)
             state.record_event("tool_executed", tool_name=tool_name, success=result.success)
@@ -199,8 +209,17 @@ class AdaptiveAgent:
             for tool in self.registry.list()
         ]
         return (
-            "You are AdaptiveAgent. Keep the user's task exactly as provided: do not rewrite, "
-            "trim, translate, change casing, or transform it. Decide using the original task only.\n"
+            "You are AdaptiveAgent, a tool-using CLI agent. Keep the user's task exactly as "
+            "provided: do not rewrite, trim, translate, change casing, or transform it. Decide "
+            "using the original task only.\n"
+            "Use tools for deterministic work, structured data processing, file operations, "
+            "tests, or calculations. For JSON, CSV, or other structured data, prefer Python code "
+            "through code_execute and use standard parsers such as json or csv; do not parse "
+            "structured data with regular expressions or brittle string splitting. If a task is "
+            "ambiguous, requires missing private credentials/data, or requires user permission, "
+            "call ask_human instead of guessing. Do not fabricate external data or credentials. "
+            "For one-off deterministic analysis, generate general Python code that solves the "
+            "class of task, not code tailored to a single expected answer.\n"
             "Return only JSON in one of these forms:\n"
             '{"action":"tool","tool_name":"<tool name>","arguments":{...}}\n'
             '{"action":"respond","response":"<answer>"}\n'

--- a/scripts/aavs_validate.py
+++ b/scripts/aavs_validate.py
@@ -1,0 +1,335 @@
+#!/usr/bin/env python3
+"""Run AdaptiveAgent validation scenarios against a real LLM provider.
+
+The prompts in this harness are intentionally general English task prompts based
+on docs/adaptive_agent_validation_scenarios.md. They avoid embedding expected
+answers as instructions so provider behavior can be observed instead of taught
+to pass a single fixture.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@dataclass(frozen=True)
+class Scenario:
+    """A single provider-facing validation scenario."""
+
+    scenario_id: str
+    title: str
+    prompt: str
+    required_events: tuple[str, ...]
+    any_events: tuple[str, ...] = ()
+    required_action: str | None = None
+    required_tool: str | None = None
+    stdout_contains: tuple[str, ...] = ()
+    output_contains_any: tuple[str, ...] = ()
+    code_contains_any: tuple[str, ...] = ()
+    expect_pass: bool = True
+    notes: str = ""
+
+
+@dataclass
+class ScenarioRecord:
+    """Serializable execution record for one scenario/provider pair."""
+
+    scenario_id: str
+    title: str
+    provider: str
+    model: str
+    prompt: str
+    command: list[str]
+    started_at: str
+    completed_at: str
+    returncode: int
+    stdout: str
+    stderr: str
+    parsed_result: dict[str, Any] | None
+    checks: dict[str, bool]
+    passed: bool
+    failure_classification: str
+    notes: str = ""
+
+    def to_markdown(self) -> str:
+        result = self.parsed_result or {}
+        events = [event.get("name") for event in result.get("events", []) if isinstance(event, dict)]
+        output = result.get("output", "")
+        tool_name = result.get("tool_name")
+        return "\n".join(
+            [
+                "## 실행 기록",
+                "",
+                f"- 시나리오 ID: {self.scenario_id}",
+                f"- 실행 일시: {self.started_at}",
+                f"- 사용 LLM provider/model: {self.provider}/{self.model}",
+                "- 실행 환경: local CLI or GitHub Actions runner",
+                f"- 사용자 입력: {self.prompt}",
+                f"- Agent 계획 요약: action={result.get('action')}, tool={tool_name}",
+                f"- 생성된 툴 이름: {tool_name or '없음'}",
+                "- 생성된 툴 저장 위치: 해당 없음(명시 저장 시나리오 제외)",
+                f"- 실행 명령: {' '.join(self.command)}",
+                f"- 실행 결과: returncode={self.returncode}",
+                f"- 오류 발생 여부: {'예' if self.stderr or self.returncode else '아니오'}",
+                "- 자가 수정 횟수: 이벤트 기반 별도 확인 필요",
+                "- 사용자 추가 입력 여부: ask_human/clarification 이벤트 기반 확인",
+                "- 저장 동의 결과: 이벤트 기반 별도 확인 필요",
+                f"- 최종 응답: {json.dumps(output, ensure_ascii=False)[:2000]}",
+                f"- 통과/실패: {'통과' if self.passed else '실패'}",
+                f"- 실패 원인 분류: {self.failure_classification}",
+                f"- 비고: events={events}; checks={self.checks}; {self.notes}",
+                "",
+            ]
+        )
+
+
+SCENARIOS: tuple[Scenario, ...] = (
+    Scenario(
+        scenario_id="AAVS-001",
+        title="Structured JSON analysis via generated Python execution",
+        prompt=(
+            "From the JSON data below, identify monsters with hp >= 100 and compute their "
+            "average hp. Use an executable tool with a standard JSON parser for the calculation, "
+            "then answer from the execution result.\n"
+            '[{"name":"Goblin","hp":80},{"name":"Orc","hp":150},{"name":"Dragon","hp":300}]'
+        ),
+        required_events=("task_received", "task_analyzed", "tool_spec_created", "tool_executed", "tool_result_observed"),
+        required_action="tool",
+        required_tool="code_execute",
+        stdout_contains=("Orc", "Dragon", "225"),
+        code_contains_any=("json.loads", "json.load"),
+    ),
+    Scenario(
+        scenario_id="AAVS-003A",
+        title="Ambiguous request asks for clarification",
+        prompt=(
+            "Clean up the data. If the request is underspecified, do not assume hidden data or "
+            "criteria; ask the user for the missing information."
+        ),
+        required_events=("task_received", "task_analyzed"),
+        any_events=("clarification_requested",),
+        required_tool="ask_human",
+        output_contains_any=("pending_human_input", "which data", "what data", "criteria", "missing"),
+    ),
+    Scenario(
+        scenario_id="AAVS-003B",
+        title="CSV deduplication and date sorting via standard parser",
+        prompt=(
+            "Remove duplicate rows from the CSV below, then sort the remaining rows by date in "
+            "ascending order. Use an executable tool with a standard CSV parser and answer from "
+            "the execution result.\n"
+            "date,name,score\n"
+            "2026-04-03,Alice,10\n"
+            "2026-04-01,Bob,20\n"
+            "2026-04-03,Alice,10\n"
+            "2026-04-02,Charlie,15"
+        ),
+        required_events=("task_received", "task_analyzed", "tool_spec_created", "tool_executed", "tool_result_observed"),
+        required_action="tool",
+        required_tool="code_execute",
+        stdout_contains=("2026-04-01,Bob,20", "2026-04-02,Charlie,15", "2026-04-03,Alice,10"),
+        code_contains_any=("csv.", "csv\n", "import csv"),
+    ),
+    Scenario(
+        scenario_id="AAVS-006",
+        title="Private database request asks for access details",
+        prompt=(
+            "Analyze the top 10 products by revenue from my private database for last month. "
+            "If credentials, connection details, schema, or access are missing, do not fabricate "
+            "data and ask for the required information."
+        ),
+        required_events=("task_received", "task_analyzed"),
+        any_events=("clarification_requested",),
+        required_tool="ask_human",
+        output_contains_any=("database", "credentials", "connection", "access", "schema", "pending_human_input"),
+    ),
+)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run AAVS provider validation scenarios")
+    parser.add_argument("--provider", choices=("openai", "ollama"), required=True)
+    parser.add_argument("--model", default="", help="Provider model override")
+    parser.add_argument(
+        "--scenario",
+        action="append",
+        choices=[scenario.scenario_id for scenario in SCENARIOS],
+        help="Scenario ID to run. Repeatable. Defaults to release-gate scenarios in this script.",
+    )
+    parser.add_argument(
+        "--scenarios",
+        nargs="+",
+        choices=[scenario.scenario_id for scenario in SCENARIOS],
+        help="Scenario IDs to run. Convenience form for GitHub workflow inputs.",
+    )
+    parser.add_argument("--output", default="", help="Write JSON execution records to this path")
+    parser.add_argument("--markdown-output", default="", help="Write markdown execution records to this path")
+    parser.add_argument("--output-dir", default="", help="Directory for records.json and records.md")
+    args = parser.parse_args()
+
+    requested = set((args.scenario or []) + (args.scenarios or []))
+    selected = [scenario for scenario in SCENARIOS if not requested or scenario.scenario_id in requested]
+    env = os.environ.copy()
+    env["ADAPTIVE_AGENT_LLM"] = args.provider
+    model = args.model or default_model(args.provider, env)
+    if args.provider == "openai":
+        env["OPENAI_MODEL"] = model
+    if args.provider == "ollama":
+        env["OLLAMA_MODEL"] = model
+
+    records: list[ScenarioRecord] = []
+    for scenario in selected:
+        records.append(run_scenario(scenario, provider=args.provider, model=model, env=env))
+
+    output_path = Path(args.output) if args.output else None
+    markdown_path = Path(args.markdown_output) if args.markdown_output else None
+    if args.output_dir:
+        output_dir = Path(args.output_dir)
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_path = output_path or output_dir / "records.json"
+        markdown_path = markdown_path or output_dir / "records.md"
+
+    if output_path:
+        output_path.write_text(
+            json.dumps([record.__dict__ for record in records], ensure_ascii=False, indent=2),
+            encoding="utf-8",
+        )
+    if markdown_path:
+        markdown_path.write_text(
+            "\n".join(record.to_markdown() for record in records),
+            encoding="utf-8",
+        )
+
+    print(json.dumps([record.__dict__ for record in records], ensure_ascii=False, indent=2))
+    return 0 if all(record.passed for record in records) else 1
+
+
+def default_model(provider: str, env: dict[str, str]) -> str:
+    if provider == "openai":
+        return env.get("OPENAI_MODEL", "gpt-5-nano")
+    return env.get("OLLAMA_MODEL", "qwen2.5:1.5b")
+
+
+def run_scenario(
+    scenario: Scenario,
+    *,
+    provider: str,
+    model: str,
+    env: dict[str, str],
+) -> ScenarioRecord:
+    started_at = utc_now()
+    command = [sys.executable, "-m", "adaptive_agent", "--json", "--llm", provider, scenario.prompt]
+    with tempfile.TemporaryDirectory(prefix=f"aavs-{scenario.scenario_id.lower()}-") as temp_dir:
+        run_env = env.copy()
+        run_env["ADAPTIVE_AGENT_WORKSPACE"] = str(REPO_ROOT)
+        run_env["ADAPTIVE_AGENT_TOOL_LIBRARY"] = str(Path(temp_dir) / "tools")
+        completed = subprocess.run(
+            command,
+            cwd=REPO_ROOT,
+            env=run_env,
+            text=True,
+            capture_output=True,
+            timeout=180,
+            check=False,
+        )
+    completed_at = utc_now()
+    parsed = parse_result(completed.stdout)
+    checks = evaluate_scenario(scenario, completed.returncode, parsed)
+    passed = all(checks.values()) if scenario.expect_pass else not all(checks.values())
+    return ScenarioRecord(
+        scenario_id=scenario.scenario_id,
+        title=scenario.title,
+        provider=provider,
+        model=model,
+        prompt=scenario.prompt,
+        command=command,
+        started_at=started_at,
+        completed_at=completed_at,
+        returncode=completed.returncode,
+        stdout=completed.stdout,
+        stderr=completed.stderr,
+        parsed_result=parsed,
+        checks=checks,
+        passed=passed,
+        failure_classification=classify_failure(completed.returncode, parsed, checks),
+        notes=scenario.notes,
+    )
+
+
+def parse_result(stdout: str) -> dict[str, Any] | None:
+    try:
+        loaded = json.loads(stdout)
+    except json.JSONDecodeError:
+        return None
+    return loaded if isinstance(loaded, dict) else None
+
+
+def evaluate_scenario(scenario: Scenario, returncode: int, parsed: dict[str, Any] | None) -> dict[str, bool]:
+    if parsed is None:
+        return {"cli_returncode": returncode == 0, "json_result": False}
+
+    events = [event.get("name") for event in parsed.get("events", []) if isinstance(event, dict)]
+    output_text = json.dumps(parsed.get("output", ""), ensure_ascii=False)
+    code_text = "\n".join(
+        str(event.get("details", {}).get("code", ""))
+        for event in parsed.get("events", [])
+        if isinstance(event, dict)
+    )
+    checks: dict[str, bool] = {
+        "cli_returncode": returncode == 0,
+        "json_result": True,
+        "required_events": all(event in events for event in scenario.required_events),
+    }
+    if scenario.any_events:
+        checks["any_expected_event"] = any(event in events for event in scenario.any_events)
+    if scenario.required_action:
+        checks["required_action"] = parsed.get("action") == scenario.required_action
+    if scenario.required_tool:
+        checks["required_tool"] = parsed.get("tool_name") == scenario.required_tool
+    if scenario.stdout_contains:
+        checks["stdout_contains"] = all(fragment in output_text for fragment in scenario.stdout_contains)
+    if scenario.output_contains_any:
+        lowered = output_text.casefold()
+        checks["output_contains_any"] = any(fragment.casefold() in lowered for fragment in scenario.output_contains_any)
+    if scenario.code_contains_any:
+        checks["code_uses_expected_parser"] = any(fragment in code_text for fragment in scenario.code_contains_any)
+    return checks
+
+
+def classify_failure(returncode: int, parsed: dict[str, Any] | None, checks: dict[str, bool]) -> str:
+    if all(checks.values()):
+        return "없음"
+    if parsed is None or returncode != 0:
+        return "외부 provider 오류 또는 CLI 실행 오류"
+    if parsed.get("action") == "llm_error":
+        return "외부 provider 오류"
+    if not checks.get("required_tool", True) or not checks.get("required_action", True):
+        return "LLM 계획 오류"
+    if not checks.get("stdout_contains", True) or not checks.get("code_uses_expected_parser", True):
+        return "생성 코드 오류 또는 실행 결과 검증 실패"
+    if not checks.get("any_expected_event", True):
+        return "사용자 입력 부족 처리 오류"
+    return "검증 기준 미충족"
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+if __name__ == "__main__":
+    if shutil.which(sys.executable) is None:
+        raise SystemExit("Python executable not found")
+    raise SystemExit(main())

--- a/scripts/aavs_validate.py
+++ b/scripts/aavs_validate.py
@@ -16,13 +16,19 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+SUPPORTED_SCENARIOS = ", ".join(scenario_id for scenario_id in ("AAVS-001", "AAVS-003A", "AAVS-003B", "AAVS-006"))
+UNSUPPORTED_SCENARIOS_NOTE = (
+    "This harness currently automates provider-facing checks for "
+    f"{SUPPORTED_SCENARIOS}. AAVS-002, AAVS-004, and AAVS-005 still require "
+    "agent self-correction and persistent tool-library workflows that are not implemented in the current CLI loop."
+)
 
 
 @dataclass(frozen=True)
@@ -62,6 +68,7 @@ class ScenarioRecord:
     checks: dict[str, bool]
     passed: bool
     failure_classification: str
+    validation_scope: dict[str, Any]
     notes: str = ""
 
     def to_markdown(self) -> str:
@@ -69,6 +76,7 @@ class ScenarioRecord:
         events = [event.get("name") for event in result.get("events", []) if isinstance(event, dict)]
         output = result.get("output", "")
         tool_name = result.get("tool_name")
+        scope = self.validation_scope
         return "\n".join(
             [
                 "## 실행 기록",
@@ -87,6 +95,7 @@ class ScenarioRecord:
                 "- 자가 수정 횟수: 이벤트 기반 별도 확인 필요",
                 "- 사용자 추가 입력 여부: ask_human/clarification 이벤트 기반 확인",
                 "- 저장 동의 결과: 이벤트 기반 별도 확인 필요",
+                f"- 검증 범위: {json.dumps(scope, ensure_ascii=False)}",
                 f"- 최종 응답: {json.dumps(output, ensure_ascii=False)[:2000]}",
                 f"- 통과/실패: {'통과' if self.passed else '실패'}",
                 f"- 실패 원인 분류: {self.failure_classification}",
@@ -182,6 +191,7 @@ def main() -> int:
 
     requested = set((args.scenario or []) + (args.scenarios or []))
     selected = [scenario for scenario in SCENARIOS if not requested or scenario.scenario_id in requested]
+    print(UNSUPPORTED_SCENARIOS_NOTE, file=sys.stderr)
     env = os.environ.copy()
     env["ADAPTIVE_AGENT_LLM"] = args.provider
     model = args.model or default_model(args.provider, env)
@@ -265,6 +275,7 @@ def run_scenario(
         checks=checks,
         passed=passed,
         failure_classification=classify_failure(completed.returncode, parsed, checks),
+        validation_scope=build_validation_scope(parsed),
         notes=scenario.notes,
     )
 
@@ -323,6 +334,34 @@ def classify_failure(returncode: int, parsed: dict[str, Any] | None, checks: dic
     if not checks.get("any_expected_event", True):
         return "사용자 입력 부족 처리 오류"
     return "검증 기준 미충족"
+
+
+def build_validation_scope(parsed: dict[str, Any] | None) -> dict[str, Any]:
+    """검증이 최종 자연어 응답까지 포함하는지, raw tool output에 머무는지 명시합니다."""
+
+    if parsed is None:
+        return {
+            "agent_result_available": False,
+            "raw_tool_output_checked": False,
+            "final_user_response_checked": False,
+            "note": "CLI did not return parseable JSON.",
+        }
+
+    action = parsed.get("action")
+    tool_name = parsed.get("tool_name")
+    raw_tool_output = action == "tool" and tool_name is not None
+    return {
+        "agent_result_available": True,
+        "raw_tool_output_checked": raw_tool_output,
+        "final_user_response_checked": action == "llm",
+        "note": (
+            "Current AdaptiveAgent returns the structured tool execution result directly after tool use; "
+            "these scenarios validate tool choice, generated code, events, and raw execution output, "
+            "not a second natural-language answer synthesis step."
+            if raw_tool_output
+            else "Scenario validation is based on the agent response payload."
+        ),
+    }
 
 
 def utc_now() -> str:

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -84,12 +84,38 @@ class AdaptiveAgentTest(unittest.TestCase):
             [
                 "task_received",
                 "task_analyzed",
+                "tool_spec_created",
                 "tool_execution_requested",
                 "tool_executed",
                 "tool_result_observed",
                 "final_response_created",
             ],
         )
+
+    def test_code_tool_plan_records_created_code_event(self) -> None:
+        llm = StubLLM(
+            '{"action":"tool","tool_name":"code_execute","arguments":'
+            '{"code":"print(225)","expected_output":"225"}}'
+        )
+        agent = AdaptiveAgent(config=AgentConfig(), llm_client=llm)
+
+        result = agent.run("구조화 데이터를 계산해줘")
+
+        event_names = [event.name for event in result.events]
+        self.assertEqual(result.action, "tool")
+        self.assertIn("tool_spec_created", event_names)
+        self.assertIn("tool_code_created", event_names)
+
+    def test_prompt_instructs_general_structured_data_tool_use(self) -> None:
+        llm = StubLLM()
+        agent = AdaptiveAgent(config=AgentConfig(), llm_client=llm)
+
+        agent.run("아래 JSON을 분석해줘: []")
+
+        prompt = llm.prompts[0]
+        self.assertIn("Use tools for deterministic work", prompt)
+        self.assertIn("standard parsers such as json or csv", prompt)
+        self.assertIn("not code tailored to a single expected answer", prompt)
 
     def test_tool_plan_without_tool_name_is_rejected(self) -> None:
         llm = StubLLM('{"action":"tool","arguments":{"task":"원문 그대로"}}')


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 요약

AAVS 시나리오를 OpenAI/Ollama 실제 provider로 실행해 tool calling, JSON/CSV 표준 파서 사용, clarification 흐름을 검증할 수 있는 하네스를 추가했습니다.

## 관련 이슈

없음

## 변경 사항

- `scripts/aavs_validate.py` 추가: AAVS-001, AAVS-003A, AAVS-003B, AAVS-006을 영어 프롬프트로 실행하고 JSON/Markdown 실행 기록을 생성
- 에이전트 이벤트에 `tool_spec_created`, `tool_code_created`, `clarification_requested` 관찰 지점 보강
- 구조화 데이터/결정론적 계산에는 `code_execute`와 표준 파서를 쓰도록 범용 프롬프트 지시 강화
- Manual LLM Check workflow에 `validation_suite=aavs` 옵션 및 artifact 업로드 추가
- Ollama/Gemini 선택 시 OpenAI 기본 모델(`gpt-5-nano`)이 잘못 전달되지 않도록 provider별 effective model 보정
- AAVS 기록에 raw tool output 검증 범위와 최종 자연어 응답 합성 미검증 범위를 명시
- README에 자동 하네스 대상/미대상 AAVS 시나리오와 현재 Agent 한계 문서화

## 테스트

- [x] `python3 -m unittest discover`
- [x] `python3 -m compileall adaptive_agent tests scripts`
- [x] `python3 scripts/aavs_validate.py --provider openai --scenario AAVS-001 --output /tmp/aavs.json --markdown-output /tmp/aavs.md` 로컬 키 없음 실패 분류/기록 생성 및 `validation_scope` 기록 확인

## 스크린샷 / 로그 (선택)

로컬 환경에는 `OPENAI_API_KEY`와 `ollama`가 없어 실제 provider 검증은 GitHub Actions의 Manual LLM Check에서 `validation_suite=aavs`로 실행해야 합니다.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af077873-3d7f-48ab-8b26-470aa5d3fe2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af077873-3d7f-48ab-8b26-470aa5d3fe2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

