### PR TITLE
test: add AAVS provider validation harness

### DIFF
--- a/adaptive_agent/llms/ollama.py
+++ b/adaptive_agent/llms/ollama.py
@@ -19,6 +19,8 @@ class OllamaClient:
         response = client.chat(
             model=self.model,
             messages=[{"role": "user", "content": prompt}],
+            format="json",
+            options={"temperature": 0},
         )
         return str(response["message"]["content"])
 

--- a/tests/test_llm_factory.py
+++ b/tests/test_llm_factory.py
@@ -50,6 +50,8 @@ class LLMFactoryTest(unittest.TestCase):
         ollama_client.chat.assert_called_once_with(
             model="qwen-test",
             messages=[{"role": "user", "content": "hello"}],
+            format="json",
+            options={"temperature": 0},
         )
 
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## 요약

AAVS 시나리오를 OpenAI/Ollama 실제 provider로 실행해 tool calling, JSON/CSV 표준 파서 사용, clarification 흐름, 제한된 self-correction을 검증할 수 있는 하네스를 추가했습니다.

## 관련 이슈

없음

## 변경 사항

- `scripts/aavs_validate.py` 추가: AAVS-001, AAVS-003A, AAVS-003B, AAVS-006을 영어 프롬프트로 실행하고 JSON/Markdown 실행 기록을 생성
- 에이전트 이벤트에 `tool_spec_created`, `tool_code_created`, `clarification_requested`, `self_correction_started`, `tool_reexecuted` 관찰 지점 보강
- 구조화 데이터/결정론적 계산에는 `code_execute`와 표준 파서를 쓰도록 범용 프롬프트 지시 강화
- JSON/CSV 샘플을 Python 객체 리터럴로 옮겨 적지 않고 원문 텍스트를 `json.loads`/`csv.DictReader` 등으로 파싱하도록 지시 강화
- 모호하거나 권한/데이터가 부족한 응답은 `needs_user_input`/clarification 이벤트 또는 직접 clarification 문장 감지로 정규화
- 툴 실행 실패 시 오류와 이전 코드를 관찰해 `ADAPTIVE_AGENT_MAX_SELF_CORRECTIONS` 제한 내에서 재계획/재실행
- LLM이 JSON plan을 markdown fence, 문자열, 또는 `response` 필드 안에 감싸 반환하는 경우를 범용적으로 파싱
- `action`에 툴 이름이 들어오거나 `arg_input`/`arg_lang` alias를 쓰는 경우를 내장 툴 계약으로 정규화
- Ollama 같은 작은 모델이 `shell_run`/`analyze_requirements`를 잘못 고르지 않도록 도구 선택 지시 강화
- Ollama 클라이언트에서 `format="json"`과 낮은 temperature를 사용해 JSON plan 응답 안정화
- Ollama 기본/문서화 모델을 `qwen3.5:2b`로 변경
- Manual LLM Check workflow에 `validation_suite=aavs` 옵션 및 artifact 업로드 추가
- Ollama/Gemini 선택 시 OpenAI 기본 모델(`gpt-5-nano`)이 잘못 전달되지 않도록 provider별 effective model 보정
- Ollama AAVS 시나리오 timeout 기본값을 600초로 늘리고, timeout 발생 시 하네스가 예외로 죽지 않고 JSON/Markdown 기록을 남기도록 보강
- 빈 timeout workflow 입력이 argparse 오류를 내지 않도록 처리
- AAVS 기록에 raw tool output 검증 범위와 최종 자연어 응답 합성 미검증 범위를 명시
- README에 자동 하네스 대상/미대상 AAVS 시나리오와 현재 Agent 한계 문서화

## 테스트

- [x] `python3 -m unittest discover`
- [x] `python3 -m compileall adaptive_agent tests scripts`
- [x] OpenAI Manual LLM Check AAVS 성공 확인
- [x] 사용자 제공 Ollama Actions 로그 분석: qwen2.5/qwen3.5의 fenced JSON plan, direct clarification response, wrong tool choice(shell_run/analyze_requirements), timeout, 빈 timeout 인자 오류 확인 후 범용 보강

## 스크린샷 / 로그 (선택)

Ollama는 `qwen3.5:2b` 기준으로 재검증이 필요합니다. Ollama 클라이언트는 이제 JSON format 모드로 plan 응답을 요청합니다.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af077873-3d7f-48ab-8b26-470aa5d3fe2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af077873-3d7f-48ab-8b26-470aa5d3fe2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

