### PR TITLE
feat(agent): run router loop with critic evaluation

### DIFF
--- a/adaptive_agent/agent.py
+++ b/adaptive_agent/agent.py
@@ -66,7 +66,9 @@ class AdaptiveAgent:
                 create_state=self._create_state,
                 plan_with_llm=self._plan_with_llm,
                 run_normalized_plan=self._run_normalized_plan,
+                critique_execution=self._critique_execution_with_llm,
                 make_response=AgentResponse,
+                max_steps=self.config.max_router_steps,
             )
         )
 
@@ -111,15 +113,18 @@ class AdaptiveAgent:
         }
         self._record_tool_result(state, tool_name, result.success, result.error)
         if result.success:
+            if tool_name in {"ask_human", "propose_actions"}:
+                state.next_node = "approve"
+                state.record_event("final_response_created", action="tool")
+                return AgentResponse(
+                    task=task,
+                    output=result.output,
+                    tool_name=tool_name,
+                    action="tool",
+                    events=state.events,
+                )
             state.next_node = "critique"
-            state.record_event("final_response_created", action="tool")
-            return AgentResponse(
-                task=task,
-                output=result.output,
-                tool_name=tool_name,
-                action="tool",
-                events=state.events,
-            )
+            return None
 
         state.failure_count += 1
         state.error_log = str(result.error or "")
@@ -178,15 +183,18 @@ class AdaptiveAgent:
             }
             self._record_tool_result(state, tool_name, result.success, result.error)
             if result.success:
+                if tool_name in {"ask_human", "propose_actions"}:
+                    state.next_node = "approve"
+                    state.record_event("final_response_created", action="tool")
+                    return AgentResponse(
+                        task=task,
+                        output=result.output,
+                        tool_name=tool_name,
+                        action="tool",
+                        events=state.events,
+                    )
                 state.next_node = "critique"
-                state.record_event("final_response_created", action="tool")
-                return AgentResponse(
-                    task=task,
-                    output=result.output,
-                    tool_name=tool_name,
-                    action="tool",
-                    events=state.events,
-                )
+                return None
             state.failure_count += 1
             state.error_log = str(result.error or "")
             state.reflections.append(f"tool_execution_error:{tool_name}:{result.error}")
@@ -268,6 +276,16 @@ class AdaptiveAgent:
         except json.JSONDecodeError:
             parsed = response
         return self._normalize_plan(parsed, fallback_response=response)
+
+    def _critique_execution_with_llm(self, state: AgentState) -> dict[str, Any]:
+        """Create a normalized critique verdict from the latest execution state."""
+
+        response = self.llm_client.complete(self._build_critic_prompt(state))
+        try:
+            parsed = self._loads_plan_json(response)
+        except json.JSONDecodeError:
+            parsed = response
+        return self._normalize_critique(parsed, fallback_response=response)
 
     def _loads_plan_json(self, response: str) -> object:
         """Decode nested or fenced LLM plan JSON into a Python object."""
@@ -403,6 +421,48 @@ class AdaptiveAgent:
             }
         arguments = self._normalize_tool_arguments(tool_name, arguments, parsed)
         return {"action": "tool", "tool_name": tool_name, "arguments": arguments}
+
+    def _normalize_critique(self, parsed: object, *, fallback_response: str) -> dict[str, Any]:
+        """Normalize critic output to verdict, reason, reflection, and next_node."""
+
+        if not isinstance(parsed, dict):
+            return {
+                "verdict": "success",
+                "reason": "critic returned non-JSON output after successful execution",
+                "reflection": str(fallback_response),
+                "next_node": "done",
+                "_validation_error": "critic_not_object",
+            }
+
+        raw_verdict = str(parsed.get("verdict") or "").strip().lower().replace("-", "_")
+        verdict_aliases = {
+            "accepted": "success",
+            "pass": "success",
+            "passed": "success",
+            "retryable": "retry",
+            "retry_needed": "retry",
+            "human": "needs_human",
+            "input_required": "needs_human",
+        }
+        verdict = verdict_aliases.get(raw_verdict, raw_verdict)
+        if verdict not in {"success", "retry", "needs_human", "unsafe", "failed"}:
+            verdict = "success"
+
+        next_node = parsed.get("next_node")
+        if not isinstance(next_node, str) or next_node not in {"plan", "approve", "store", "done", "error"}:
+            next_node = {
+                "success": "done",
+                "retry": "plan",
+                "needs_human": "approve",
+                "unsafe": "error",
+                "failed": "error",
+            }[verdict]
+        return {
+            "verdict": verdict,
+            "reason": str(parsed.get("reason") or ""),
+            "reflection": str(parsed.get("reflection") or ""),
+            "next_node": next_node,
+        }
 
     def _normalize_plan_action_alias(self, parsed: dict[str, Any]) -> dict[str, Any]:
         """Map node-level plan actions to the executable plan contract."""
@@ -565,6 +625,18 @@ class AdaptiveAgent:
             failed_plan=json.dumps(failed_plan, ensure_ascii=False),
             error=error,
             output=json.dumps(output, ensure_ascii=False, default=str),
+        )
+
+    def _build_critic_prompt(self, state: AgentState) -> str:
+        """Render the Critic Agent prompt from the latest execution state."""
+
+        return self.prompt_loader.render(
+            "critic.txt",
+            task=state.user_task,
+            current_plan=json.dumps(state.current_plan, ensure_ascii=False, default=str),
+            last_tool_result=json.dumps(state.last_tool_result, ensure_ascii=False, default=str),
+            error_log=state.error_log,
+            reflections=json.dumps(state.reflections, ensure_ascii=False, default=str),
         )
 
     def _create_state(self) -> AgentState:

--- a/adaptive_agent/config.py
+++ b/adaptive_agent/config.py
@@ -30,6 +30,10 @@ class AgentConfig:
     workspace_dir: Path = Path.cwd()
     tool_library_dir: Path = Path.cwd() / ".adaptive_agent" / "tools"
     max_self_corrections: int = 2
+    max_router_steps: int = 8
+    ollama_timeout_seconds: float = 60.0
+    ollama_num_predict: int = 256
+    ollama_think: bool = False
 
     @classmethod
     def from_env(
@@ -66,4 +70,8 @@ class AgentConfig:
             workspace_dir=workspace_dir,
             tool_library_dir=tool_library_dir,
             max_self_corrections=int(os.getenv("ADAPTIVE_AGENT_MAX_SELF_CORRECTIONS", "2")),
+            max_router_steps=int(os.getenv("ADAPTIVE_AGENT_MAX_ROUTER_STEPS", "8")),
+            ollama_timeout_seconds=float(os.getenv("OLLAMA_TIMEOUT_SECONDS", "60")),
+            ollama_num_predict=int(os.getenv("OLLAMA_NUM_PREDICT", "256")),
+            ollama_think=os.getenv("OLLAMA_THINK", "false").strip().lower() in {"1", "true", "yes", "on"},
         )

--- a/adaptive_agent/llms/factory.py
+++ b/adaptive_agent/llms/factory.py
@@ -11,7 +11,13 @@ def create_llm_client(config: AgentConfig, provider: str | None = None) -> LLMCl
     """Create an LLM client for the selected provider."""
     selected_provider = (provider or config.llm_provider).lower()
     if selected_provider == "ollama":
-        return OllamaClient(model=config.ollama_model, host=config.ollama_host)
+        return OllamaClient(
+            model=config.ollama_model,
+            host=config.ollama_host,
+            timeout_seconds=config.ollama_timeout_seconds,
+            num_predict=config.ollama_num_predict,
+            think=config.ollama_think,
+        )
     if selected_provider == "openai":
         from adaptive_agent.llms.openai_client import OpenAIClient
 

--- a/adaptive_agent/llms/ollama.py
+++ b/adaptive_agent/llms/ollama.py
@@ -8,17 +8,33 @@ from adaptive_agent.llms.base import LLMClient
 class OllamaClient:
     """LLM client backed by a local Ollama model."""
 
-    def __init__(self, model: str, *, host: str | None = None) -> None:
+    def __init__(
+        self,
+        model: str,
+        *,
+        host: str | None = None,
+        timeout_seconds: float = 60.0,
+        num_predict: int = 256,
+        think: bool = False,
+    ) -> None:
         self.model = model
         self.host = host
+        self.timeout_seconds = timeout_seconds
+        self.num_predict = num_predict
+        self.think = think
 
     def generate(self, prompt: str) -> str:
         import ollama
 
-        client = ollama.Client(host=self.host) if self.host else ollama.Client()
+        client_kwargs = {"timeout": self.timeout_seconds}
+        if self.host:
+            client_kwargs["host"] = self.host
+        client = ollama.Client(**client_kwargs)
         response = client.chat(
             model=self.model,
             messages=[{"role": "user", "content": prompt}],
+            options={"temperature": 0, "num_predict": self.num_predict},
+            think=self.think,
         )
         return str(response["message"]["content"])
 
@@ -28,5 +44,18 @@ class OllamaClient:
         return self.generate(prompt)
 
 
-def create_ollama_client(model: str, *, host: str | None = None) -> LLMClient:
-    return OllamaClient(model=model, host=host)
+def create_ollama_client(
+    model: str,
+    *,
+    host: str | None = None,
+    timeout_seconds: float = 60.0,
+    num_predict: int = 256,
+    think: bool = False,
+) -> LLMClient:
+    return OllamaClient(
+        model=model,
+        host=host,
+        timeout_seconds=timeout_seconds,
+        num_predict=num_predict,
+        think=think,
+    )

--- a/adaptive_agent/nodes/__init__.py
+++ b/adaptive_agent/nodes/__init__.py
@@ -3,6 +3,7 @@
 from adaptive_agent.nodes.base import AgentNode, BaseAgentNode, NodeResult
 from adaptive_agent.nodes.coder import CoderNode
 from adaptive_agent.nodes.critic import CriticNode
+from adaptive_agent.nodes.execute import ExecuteNode
 from adaptive_agent.nodes.plan import PlanNode
 
-__all__ = ["AgentNode", "BaseAgentNode", "CoderNode", "CriticNode", "NodeResult", "PlanNode"]
+__all__ = ["AgentNode", "BaseAgentNode", "CoderNode", "CriticNode", "ExecuteNode", "NodeResult", "PlanNode"]

--- a/adaptive_agent/nodes/critic.py
+++ b/adaptive_agent/nodes/critic.py
@@ -1,12 +1,60 @@
-"""Critic agent node contract."""
+"""Critic agent node implementation."""
 
 from __future__ import annotations
 
-from adaptive_agent.nodes.base import BaseAgentNode
+from collections.abc import Callable
+from typing import Any
+
+from adaptive_agent.nodes.base import BaseAgentNode, NodeResult
+from adaptive_agent.state import AgentState, NodeName
 
 
 class CriticNode(BaseAgentNode):
-    """Node metadata for future critique and reflection workflows."""
+    """Node that evaluates the latest execution observation."""
 
-    def __init__(self) -> None:
+    critic: Callable[[AgentState], dict[str, Any]]
+
+    def __init__(self, critic: Callable[[AgentState], dict[str, Any]] | None = None) -> None:
         super().__init__(name="critique", prompt_template="critic.txt")
+        self.critic = critic or _default_critic
+
+    def run(self, state: AgentState) -> NodeResult:
+        """Classify execution outcome and choose the next node."""
+
+        verdict = self.critic(state)
+        normalized_verdict = str(verdict.get("verdict") or "success").strip().lower().replace("-", "_")
+        reflection = verdict.get("reflection")
+        if isinstance(reflection, str) and reflection:
+            state.reflections.append(reflection)
+
+        next_node = _next_node_for_verdict(normalized_verdict, verdict.get("next_node"))
+        state.next_node = next_node
+        state.record_event(
+            "execution_critiqued",
+            verdict=normalized_verdict,
+            next_node=next_node,
+            has_reflection=bool(reflection),
+        )
+        return NodeResult(next_node=next_node, details={"critique": verdict})
+
+
+def _default_critic(state: AgentState) -> dict[str, Any]:
+    result = state.last_tool_result or {}
+    return {
+        "verdict": "success" if result.get("success") is not False else "failed",
+        "reason": "default critic",
+        "reflection": "",
+        "next_node": "done",
+    }
+
+
+def _next_node_for_verdict(verdict: str, requested_next_node: object) -> NodeName:
+    if requested_next_node in {"plan", "approve", "store", "done", "error"}:
+        return requested_next_node  # type: ignore[return-value]
+    if verdict in {"success", "accepted", "pass", "passed"}:
+        return "done"
+    if verdict in {"retry", "retryable", "retry_needed"}:
+        return "plan"
+    if verdict in {"needs_human", "needs_input", "approval_required"}:
+        return "approve"
+    return "error"

--- a/adaptive_agent/nodes/execute.py
+++ b/adaptive_agent/nodes/execute.py
@@ -1,0 +1,28 @@
+"""Tool execution node for normalized plans."""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+from adaptive_agent.nodes.base import BaseAgentNode, NodeResult
+from adaptive_agent.state import AgentState
+
+
+class ExecuteNode(BaseAgentNode):
+    """Node that executes the current normalized tool plan."""
+
+    executor: Callable[[str, dict[str, Any], AgentState], Any]
+
+    def __init__(self, executor: Callable[[str, dict[str, Any], AgentState], Any]) -> None:
+        super().__init__(name="execute", prompt_template="")
+        self.executor = executor
+
+    def run(self, state: AgentState) -> NodeResult:
+        """Execute `AgentState.current_plan` and return the next node."""
+
+        response = self.executor(state.user_task, state.current_plan, state)
+        details: dict[str, object] = {}
+        if response is not None:
+            details["response"] = response
+        return NodeResult(next_node=state.next_node, details=details)

--- a/adaptive_agent/prompts/default/critic.txt
+++ b/adaptive_agent/prompts/default/critic.txt
@@ -32,3 +32,10 @@ QUALITY BAR
 OUTPUT
 - Return only raw JSON, with no Markdown fences:
 {"verdict":"success|retry|needs_human|unsafe|failed","reason":"<short reason>","reflection":"<reusable lesson>","next_node":"code|approve|store|done|error"}
+
+CONTEXT
+Original user task: {task}
+Current plan: {current_plan}
+Latest tool result: {last_tool_result}
+Error log: {error_log}
+Prior reflections: {reflections}

--- a/adaptive_agent/router.py
+++ b/adaptive_agent/router.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Any, Callable
 
-from adaptive_agent.nodes import PlanNode
+from adaptive_agent.nodes import CriticNode, ExecuteNode, PlanNode
 from adaptive_agent.state import AgentState
 
 
@@ -16,7 +16,9 @@ class RouterDependencies:
     create_state: Callable[[], AgentState]
     plan_with_llm: Callable[[str], dict[str, Any]]
     run_normalized_plan: Callable[[str, dict[str, Any], AgentState], Any]
+    critique_execution: Callable[[AgentState], dict[str, Any]]
     make_response: Callable[..., Any]
+    max_steps: int = 8
 
 
 class StateMachineRouter:
@@ -25,6 +27,8 @@ class StateMachineRouter:
     def __init__(self, dependencies: RouterDependencies) -> None:
         self.dependencies = dependencies
         self.plan_node = PlanNode(dependencies.plan_with_llm)
+        self.execute_node = ExecuteNode(dependencies.run_normalized_plan)
+        self.critic_node = CriticNode(dependencies.critique_execution)
         self.last_state: AgentState | None = None
 
     def run(self, task: str) -> Any:
@@ -37,49 +41,94 @@ class StateMachineRouter:
         state.record_event("task_received", task=task)
 
         if task == "":
-            state.next_node = "done"
             state.record_event("clarification_requested", reason="empty_task")
-            state.record_event("final_response_created", action="input_required")
-            return self.dependencies.make_response(
-                task=task,
-                output="작업 내용을 입력해 주세요.",
-                action="input_required",
-                events=state.events,
-            )
+            return self._final_response(state, output="작업 내용을 입력해 주세요.", action="input_required")
 
         state.append_message("user", task)
-        try:
-            node_result = self.plan_node.run(state)
-        except Exception as exc:
-            state.next_node = "error"
-            state.failure_count += 1
-            state.error_log = str(exc)
-            state.record_event("failure_classified", reason="external_provider_error")
-            state.record_event("final_response_created", action="llm_error")
-            return self.dependencies.make_response(
-                task=task,
-                output=f"LLM 호출 실패: {exc}",
-                action="llm_error",
-                events=state.events,
-            )
 
-        plan = node_result.details.get("plan", {})
-        if not isinstance(plan, dict):
-            plan = {}
-        response = self.dependencies.run_normalized_plan(task, plan, state)
-        if response is not None:
-            state.next_node = "done"
-            return response
+        for _step in range(self.dependencies.max_steps):
+            try:
+                response = self._run_next_node(state)
+            except Exception as exc:
+                state.next_node = "error"
+                state.failure_count += 1
+                state.error_log = str(exc)
+                state.record_event("failure_classified", reason="external_provider_error")
+                return self._final_response(state, output=f"LLM 호출 실패: {exc}", action="llm_error")
+            if response is not None:
+                return response
 
+        state.next_node = "error"
+        state.failure_count += 1
+        state.error_log = "router_step_limit_exceeded"
+        state.record_event("failure_classified", reason="router_step_limit_exceeded")
+        return self._final_response(state, output="라우터 실행 단계 한도를 초과했습니다.", action="router_error")
+
+    def _run_next_node(self, state: AgentState) -> Any | None:
+        if state.next_node == "plan":
+            self.plan_node.run(state)
+            if state.next_node in {"done", "approve"}:
+                return self._response_from_current_plan(state)
+            return None
+
+        if state.next_node == "execute":
+            node_result = self.execute_node.run(state)
+            response = node_result.details.get("response")
+            if response is not None:
+                return response
+            return None
+
+        if state.next_node == "critique":
+            self.critic_node.run(state)
+            if state.next_node == "done":
+                return self._tool_response_from_state(state)
+            if state.next_node == "approve":
+                return self._final_response(state, output=state.last_tool_result or {}, action="approval_required")
+            if state.next_node == "error":
+                return self._final_response(state, output=state.error_log or "Critic rejected execution.", action="critic_error")
+            return None
+
+        if state.next_node == "done":
+            return self._response_from_current_plan(state)
+        if state.next_node == "approve":
+            return self._response_from_current_plan(state, action="approval_required")
+        if state.next_node == "error":
+            return self._final_response(state, output=state.error_log, action="error")
+
+        state.next_node = "error"
+        state.record_event("failure_classified", reason="unknown_next_node")
+        return self._final_response(state, output="알 수 없는 라우터 상태입니다.", action="router_error")
+
+    def _response_from_current_plan(self, state: AgentState, action: str = "llm") -> Any:
+        plan = state.current_plan
         if plan.get("needs_user_input"):
-            state.next_node = "approve"
             state.record_event("clarification_requested", reason="llm_requested_user_input")
-        else:
-            state.next_node = "done"
-        state.record_event("final_response_created", action="llm")
+            action = "approval_required"
+        return self._final_response(state, output=plan.get("response", ""), action=action)
+
+    def _tool_response_from_state(self, state: AgentState) -> Any:
+        result = state.last_tool_result or {}
+        return self._final_response(
+            state,
+            output=result.get("output"),
+            action="tool",
+            tool_name=state.last_tool_name,
+        )
+
+    def _final_response(
+        self,
+        state: AgentState,
+        *,
+        output: Any,
+        action: str,
+        tool_name: str | None = None,
+    ) -> Any:
+        state.next_node = "done" if state.next_node != "error" else "error"
+        state.record_event("final_response_created", action=action)
         return self.dependencies.make_response(
-            task=task,
-            output=plan.get("response", ""),
-            action="llm",
+            task=state.user_task,
+            output=output,
+            tool_name=tool_name,
+            action=action,
             events=state.events,
         )

--- a/docs/architecture_blueprint.md
+++ b/docs/architecture_blueprint.md
@@ -29,6 +29,23 @@ User / CLI
   -> SkillCatalog
 ```
 
+## 1차 구현 루프
+
+상세 구현의 첫 목표는 전체 목표 아키텍처를 한 번에 완성하는 것이 아니라, 라우터가 `AgentState.next_node`를 기준으로 실제 노드 루프를 돌게 만드는 것입니다.
+
+```mermaid
+flowchart TD
+  userTask["User Task"] --> planNode["PlanNode"]
+  planNode --> executeNode["ExecuteNode"]
+  executeNode --> criticNode["CriticNode"]
+  criticNode -->|"accepted"| doneNode["Done"]
+  criticNode -->|"retry needed"| planNode
+  planNode -->|"needs user input"| approvalResponse["Approval/Input Response"]
+  executeNode -->|"tool failure"| planNode
+```
+
+1차 구현 범위는 `plan -> execute -> critique -> done/error`입니다. 사용자 승인이나 추가 입력이 필요하면 상태와 응답을 반환하는 선에서 멈추고, CLI 세션 재개와 승인 입력 루프는 다음 단계에서 다룹니다.
+
 ## 목표 모듈 역할
 
 | 영역 | 책임 |

--- a/tests/test_agent.py
+++ b/tests/test_agent.py
@@ -44,6 +44,19 @@ class FailingLLM:
         raise ValueError("LLM 연결 실패")
 
 
+class AlternatingRetryLLM:
+    """테스트용 반복 LLM 클라이언트."""
+
+    def __init__(self) -> None:
+        self.prompts: list[str] = []
+
+    def complete(self, prompt: str) -> str:
+        self.prompts.append(prompt)
+        if len(self.prompts) % 2 == 1:
+            return '{"action":"tool","tool_name":"echo","arguments":{"task":"retry target"}}'
+        return '{"verdict":"retry","reason":"retry requested","reflection":"try again","next_node":"plan"}'
+
+
 class AdaptiveAgentTest(unittest.TestCase):
     def test_empty_task_only_rejects_exact_empty_string(self) -> None:
         agent = AdaptiveAgent(config=AgentConfig(), llm_client=StubLLM())
@@ -96,18 +109,10 @@ class AdaptiveAgentTest(unittest.TestCase):
         self.assertEqual(result.output, "원문 그대로")
         self.assertEqual(result.tool_name, "echo")
         self.assertEqual(result.action, "tool")
-        self.assertEqual(
-            [event.name for event in result.events],
-            [
-                "task_received",
-                "task_analyzed",
-                "tool_spec_created",
-                "tool_execution_requested",
-                "tool_executed",
-                "tool_result_observed",
-                "final_response_created",
-            ],
-        )
+        event_names = [event.name for event in result.events]
+        self.assertLess(event_names.index("task_analyzed"), event_names.index("tool_execution_requested"))
+        self.assertLess(event_names.index("tool_result_observed"), event_names.index("execution_critiqued"))
+        self.assertLess(event_names.index("execution_critiqued"), event_names.index("final_response_created"))
         self.assertIsInstance(agent.router, StateMachineRouter)
         self.assertIsNotNone(agent.router.last_state)
         self.assertEqual(agent.router.last_state.user_task, "사용자 원문")
@@ -189,12 +194,39 @@ class AdaptiveAgentTest(unittest.TestCase):
         self.assertEqual(result.action, "tool")
         self.assertIn("self_correction_started", event_names)
         self.assertIn("tool_reexecuted", event_names)
+        self.assertIn("execution_critiqued", event_names)
         self.assertIn("fixed", str(result.output))
-        self.assertEqual(len(llm.prompts), 2)
+        self.assertGreaterEqual(len(llm.prompts), 2)
         self.assertIn("repairing a failed tool execution", llm.prompts[1])
         self.assertIn("Original user task: 코드 실행 오류를 고쳐줘", llm.prompts[1])
         self.assertIn("Failed plan:", llm.prompts[1])
         self.assertIn("Observed error:", llm.prompts[1])
+
+    def test_critic_retry_routes_back_to_plan(self) -> None:
+        llm = SequenceLLM(
+            [
+                '{"action":"tool","tool_name":"echo","arguments":{"task":"first"}}',
+                '{"verdict":"retry","reason":"needs another plan","reflection":"retry once","next_node":"plan"}',
+                '{"action":"final_answer","answer":"재계획 완료"}',
+            ]
+        )
+        agent = AdaptiveAgent(config=AgentConfig(), llm_client=llm)
+
+        result = agent.run("재계획이 필요한 작업")
+
+        event_names = [event.name for event in result.events]
+        self.assertEqual(result.action, "llm")
+        self.assertEqual(result.output, "재계획 완료")
+        self.assertGreaterEqual(event_names.count("task_analyzed"), 2)
+        self.assertIn("execution_critiqued", event_names)
+
+    def test_router_step_limit_stops_repeating_loops(self) -> None:
+        agent = AdaptiveAgent(config=AgentConfig(max_router_steps=3), llm_client=AlternatingRetryLLM())
+
+        result = agent.run("반복되는 작업")
+
+        self.assertEqual(result.action, "router_error")
+        self.assertIn("router_step_limit_exceeded", [event.details.get("reason") for event in result.events])
 
     def test_default_correction_prompt_file_renders_failure_context(self) -> None:
         loader = PromptLoader()

--- a/tests/test_llm_factory.py
+++ b/tests/test_llm_factory.py
@@ -13,13 +13,22 @@ from adaptive_agent.llms.ollama import OllamaClient
 
 
 class LLMFactoryTest(unittest.TestCase):
-    def test_ollama_client_receives_model_and_host(self) -> None:
-        config = AgentConfig(ollama_model="qwen-test", ollama_host="http://localhost:11434")
+    def test_ollama_client_receives_runtime_config(self) -> None:
+        config = AgentConfig(
+            ollama_model="qwen-test",
+            ollama_host="http://localhost:11434",
+            ollama_timeout_seconds=12.5,
+            ollama_num_predict=64,
+            ollama_think=True,
+        )
 
         client = create_llm_client(config, provider="ollama")
 
         self.assertEqual(client.model, "qwen-test")
         self.assertEqual(client.host, "http://localhost:11434")
+        self.assertEqual(client.timeout_seconds, 12.5)
+        self.assertEqual(client.num_predict, 64)
+        self.assertTrue(client.think)
 
     def test_openai_provider_uses_configured_model(self) -> None:
         config = AgentConfig(openai_model="gpt-5-nano")
@@ -43,13 +52,21 @@ class LLMFactoryTest(unittest.TestCase):
         ollama_module = SimpleNamespace(Client=Mock(return_value=ollama_client))
 
         with patch.dict(sys.modules, {"ollama": ollama_module}):
-            result = OllamaClient(model="qwen-test", host="http://ollama.test:11434").complete("hello")
+            result = OllamaClient(
+                model="qwen-test",
+                host="http://ollama.test:11434",
+                timeout_seconds=12.5,
+                num_predict=64,
+                think=False,
+            ).complete("hello")
 
         self.assertEqual(result, "ok")
-        ollama_module.Client.assert_called_once_with(host="http://ollama.test:11434")
+        ollama_module.Client.assert_called_once_with(host="http://ollama.test:11434", timeout=12.5)
         ollama_client.chat.assert_called_once_with(
             model="qwen-test",
             messages=[{"role": "user", "content": "hello"}],
+            options={"temperature": 0, "num_predict": 64},
+            think=False,
         )
 
 


### PR DESCRIPTION
## Summary
- Add a real next-node router loop for `plan -> execute -> critique -> done/error`.
- Add `ExecuteNode` and connect `CriticNode` to LLM-based execution review.
- Configure Ollama runtime limits and disable thinking by default so `qwen3.5:2b` returns usable response content.

## Test plan
- [x] `.venv/bin/python -m compileall adaptive_agent tests`
- [x] `.venv/bin/python -m unittest discover` (68 tests)
- [x] `OLLAMA_NUM_PREDICT=128 .venv/bin/python -m adaptive_agent --llm ollama --json "echo smoke"`
- [x] `OLLAMA_NUM_PREDICT=192 .venv/bin/python -m adaptive_agent --llm ollama --json "Use the echo tool with task value smoke_tool"`


Made with [Cursor](https://cursor.com)