### PR TITLE
feat(sessions): add TTL/cap cleanup policy for pending sessions (closes #13)

### DIFF
--- a/adaptive_agent/agent.py
+++ b/adaptive_agent/agent.py
@@ -84,6 +84,7 @@ class AdaptiveAgent:
         self.executor = executor or ToolExecutor(self.registry)
         self.prompt_loader = prompt_loader or PromptLoader()
         self.session_store = SessionStore(self.config.session_dir)
+        self._cleanup_summary: dict[str, Any] = self._maybe_cleanup_sessions()
         self.skill_catalog = SkillCatalog(self.config.tool_library_dir)
         self.router = StateMachineRouter(
             RouterDependencies(
@@ -98,6 +99,20 @@ class AdaptiveAgent:
                 max_steps=self.config.max_router_steps,
             )
         )
+
+    def _maybe_cleanup_sessions(self) -> dict[str, Any]:
+        """Run TTL/count cleanup if enabled in config, return the summary."""
+
+        if not self.config.session_cleanup_enabled:
+            return {"deleted": [], "reasons": {}}
+        try:
+            return self.session_store.cleanup_expired(
+                max_age_days=self.config.session_max_age_days,
+                max_count=self.config.session_max_count,
+            )
+        except OSError:
+            # Non-fatal: agent must boot even if the sessions dir is unreadable.
+            return {"deleted": [], "reasons": {}}
 
     def list_tools(self) -> list:
         """Return currently registered tools."""

--- a/adaptive_agent/config.py
+++ b/adaptive_agent/config.py
@@ -32,6 +32,9 @@ class AgentConfig:
     session_dir: Path = Path.cwd() / ".adaptive_agent" / "sessions"
     max_self_corrections: int = 2
     max_router_steps: int = 8
+    session_cleanup_enabled: bool = True
+    session_max_age_days: int = 30
+    session_max_count: int = 100
     ollama_timeout_seconds: float = 60.0
     ollama_num_predict: int = 256
     ollama_think: bool = False
@@ -79,6 +82,9 @@ class AgentConfig:
             session_dir=session_dir,
             max_self_corrections=int(os.getenv("ADAPTIVE_AGENT_MAX_SELF_CORRECTIONS", "2")),
             max_router_steps=int(os.getenv("ADAPTIVE_AGENT_MAX_ROUTER_STEPS", "8")),
+            session_cleanup_enabled=os.getenv("ADAPTIVE_AGENT_SESSION_CLEANUP", "true").strip().lower() in {"1", "true", "yes", "on"},
+            session_max_age_days=int(os.getenv("ADAPTIVE_AGENT_SESSION_MAX_AGE_DAYS", "30")),
+            session_max_count=int(os.getenv("ADAPTIVE_AGENT_SESSION_MAX_COUNT", "100")),
             ollama_timeout_seconds=float(os.getenv("OLLAMA_TIMEOUT_SECONDS", "60")),
             ollama_num_predict=int(os.getenv("OLLAMA_NUM_PREDICT", "256")),
             ollama_think=os.getenv("OLLAMA_THINK", "false").strip().lower() in {"1", "true", "yes", "on"},

--- a/adaptive_agent/sessions.py
+++ b/adaptive_agent/sessions.py
@@ -18,6 +18,18 @@ def _utc_now() -> str:
     return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
 
 
+def _parse_iso8601(text: str) -> datetime | None:
+    """Parse an ISO-8601 timestamp written by ``_utc_now`` (or compatible)."""
+
+    if not text:
+        return None
+    candidate = text.replace("Z", "+00:00")
+    try:
+        return datetime.fromisoformat(candidate)
+    except ValueError:
+        return None
+
+
 @dataclass(frozen=True)
 class SessionStore:
     """Store and load minimal pending HITL session snapshots."""
@@ -75,6 +87,74 @@ class SessionStore:
         payload["status"] = status
         payload["updated_at"] = _utc_now()
         self._path_for(session_id).write_text(json.dumps(payload, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    def cleanup_expired(
+        self,
+        *,
+        max_age_days: int = 30,
+        max_count: int = 100,
+        now: datetime | None = None,
+    ) -> dict[str, Any]:
+        """Delete session snapshots that exceed TTL or count cap.
+
+        Both rules apply (deletion happens if *either* condition is met):
+
+        - TTL: ``updated_at`` older than ``max_age_days`` from ``now`` (UTC).
+        - Cap: keep at most ``max_count`` most-recently-updated sessions.
+
+        Returns ``{"deleted": [session_ids...], "reasons": {sid: "ttl"|"cap"}}``.
+        Sessions in ``pending`` state are *not* spared — long-abandoned pending
+        flows are real garbage too. Files that fail to parse are also deleted
+        (treated as corrupt) and logged as ``corrupt``.
+        """
+
+        now = now or datetime.now(timezone.utc)
+        if not self.sessions_dir.exists():
+            return {"deleted": [], "reasons": {}}
+
+        entries: list[tuple[Path, datetime, str]] = []
+        deleted: list[str] = []
+        reasons: dict[str, str] = {}
+        for path in self.sessions_dir.glob("*.json"):
+            session_id = path.stem
+            if not _SESSION_ID_PATTERN.match(session_id):
+                continue
+            try:
+                payload = json.loads(path.read_text(encoding="utf-8"))
+                updated_at = _parse_iso8601(str(payload.get("updated_at") or payload.get("created_at") or ""))
+            except (OSError, json.JSONDecodeError, ValueError):
+                path.unlink(missing_ok=True)
+                deleted.append(session_id)
+                reasons[session_id] = "corrupt"
+                continue
+            if updated_at is None:
+                # No timestamp — treat as ancient, prune.
+                path.unlink(missing_ok=True)
+                deleted.append(session_id)
+                reasons[session_id] = "ttl"
+                continue
+            entries.append((path, updated_at, session_id))
+
+        # Apply TTL.
+        ttl_threshold = now.timestamp() - max_age_days * 86400
+        survivors: list[tuple[Path, datetime, str]] = []
+        for path, updated_at, session_id in entries:
+            if updated_at.timestamp() < ttl_threshold:
+                path.unlink(missing_ok=True)
+                deleted.append(session_id)
+                reasons[session_id] = "ttl"
+            else:
+                survivors.append((path, updated_at, session_id))
+
+        # Apply count cap on what's left, oldest first.
+        if len(survivors) > max_count:
+            survivors.sort(key=lambda item: item[1])
+            for path, _updated_at, session_id in survivors[: len(survivors) - max_count]:
+                path.unlink(missing_ok=True)
+                deleted.append(session_id)
+                reasons[session_id] = "cap"
+
+        return {"deleted": deleted, "reasons": reasons}
 
     def _path_for(self, session_id: str) -> Path:
         if not _SESSION_ID_PATTERN.match(session_id):

--- a/tests/test_sessions_store.py
+++ b/tests/test_sessions_store.py
@@ -174,5 +174,167 @@ class InputVariationContractTest(unittest.TestCase):
         self.assertIn(loaded["pending_output"], ["string output value", {"status": "pending"}])
 
 
+class SessionCleanupTest(unittest.TestCase):
+    """cleanup_expired의 TTL/cap 정책 검증."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.dir = Path(self.tmp.name)
+        self.store = SessionStore(sessions_dir=self.dir)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _seed(self, session_id: str, *, days_old: int) -> None:
+        """Write a session payload with updated_at days_old days in the past."""
+
+        from datetime import datetime, timedelta, timezone
+
+        ts = datetime.now(timezone.utc) - timedelta(days=days_old)
+        payload = {
+            "session_id": session_id,
+            "status": "pending",
+            "user_task": f"task-{session_id[:6]}",
+            "updated_at": ts.isoformat().replace("+00:00", "Z"),
+        }
+        (self.dir / f"{session_id}.json").write_text(json.dumps(payload), encoding="utf-8")
+
+    def test_cleanup_on_empty_dir_returns_no_deletions(self) -> None:
+        result = self.store.cleanup_expired()
+        self.assertEqual(result, {"deleted": [], "reasons": {}})
+
+    def test_ttl_deletes_old_sessions(self) -> None:
+        self._seed("a" * 32, days_old=45)  # past TTL
+        self._seed("b" * 32, days_old=10)  # within TTL
+
+        result = self.store.cleanup_expired(max_age_days=30, max_count=100)
+
+        self.assertIn("a" * 32, result["deleted"])
+        self.assertNotIn("b" * 32, result["deleted"])
+        self.assertEqual(result["reasons"]["a" * 32], "ttl")
+        self.assertFalse((self.dir / ("a" * 32 + ".json")).exists())
+        self.assertTrue((self.dir / ("b" * 32 + ".json")).exists())
+
+    def test_cap_deletes_oldest_first(self) -> None:
+        # 5 fresh sessions, cap to 2 → oldest 3 deleted.
+        for i in range(5):
+            self._seed(f"{i}" * 32, days_old=i)  # i=0 newest, i=4 oldest
+
+        result = self.store.cleanup_expired(max_age_days=365, max_count=2)
+
+        self.assertEqual(len(result["deleted"]), 3)
+        # Three oldest (days_old=4,3,2) should be deleted.
+        for sid in ("4" * 32, "3" * 32, "2" * 32):
+            self.assertIn(sid, result["deleted"])
+            self.assertEqual(result["reasons"][sid], "cap")
+        # Two newest survive.
+        self.assertTrue((self.dir / ("0" * 32 + ".json")).exists())
+        self.assertTrue((self.dir / ("1" * 32 + ".json")).exists())
+
+    def test_ttl_takes_precedence_over_cap(self) -> None:
+        # Mix: 2 ancient (TTL) + 3 fresh (within cap).
+        self._seed("a" * 32, days_old=60)
+        self._seed("b" * 32, days_old=50)
+        self._seed("0" * 32, days_old=0)
+        self._seed("1" * 32, days_old=1)
+        self._seed("2" * 32, days_old=2)
+
+        result = self.store.cleanup_expired(max_age_days=30, max_count=100)
+
+        self.assertEqual(set(result["deleted"]), {"a" * 32, "b" * 32})
+        self.assertTrue(all(r == "ttl" for r in result["reasons"].values()))
+
+    def test_corrupt_files_are_deleted(self) -> None:
+        sid = "c" * 32
+        (self.dir / f"{sid}.json").write_text("not json{{{", encoding="utf-8")
+
+        result = self.store.cleanup_expired()
+
+        self.assertIn(sid, result["deleted"])
+        self.assertEqual(result["reasons"][sid], "corrupt")
+        self.assertFalse((self.dir / f"{sid}.json").exists())
+
+    def test_files_without_session_id_pattern_are_left_alone(self) -> None:
+        (self.dir / "not-a-session.json").write_text("{}", encoding="utf-8")
+        (self.dir / "README.txt").write_text("docs", encoding="utf-8")
+
+        result = self.store.cleanup_expired()
+
+        self.assertEqual(result["deleted"], [])
+        self.assertTrue((self.dir / "not-a-session.json").exists())
+        self.assertTrue((self.dir / "README.txt").exists())
+
+
+class AgentInitCleanupTest(unittest.TestCase):
+    """AdaptiveAgent.__init__이 cleanup을 옵션대로 호출하는지."""
+
+    def test_init_runs_cleanup_when_enabled(self) -> None:
+        from datetime import datetime, timedelta, timezone
+
+        from adaptive_agent.agent import AdaptiveAgent
+        from adaptive_agent.config import AgentConfig
+
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            session_dir = workspace / ".adaptive_agent" / "sessions"
+            session_dir.mkdir(parents=True)
+            old_id = "f" * 32
+            ts = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat().replace("+00:00", "Z")
+            (session_dir / f"{old_id}.json").write_text(
+                json.dumps({"session_id": old_id, "status": "pending", "updated_at": ts}),
+                encoding="utf-8",
+            )
+
+            class _StubLLM:
+                def complete(self, _p):  # noqa: D401
+                    return "ok"
+
+            agent = AdaptiveAgent(
+                config=AgentConfig(
+                    workspace_dir=workspace,
+                    tool_library_dir=workspace / ".adaptive_agent" / "tools",
+                    session_dir=session_dir,
+                ),
+                llm_client=_StubLLM(),
+            )
+
+            self.assertIn(old_id, agent._cleanup_summary["deleted"])
+            self.assertFalse((session_dir / f"{old_id}.json").exists())
+
+    def test_init_skips_cleanup_when_disabled(self) -> None:
+        from datetime import datetime, timedelta, timezone
+
+        from adaptive_agent.agent import AdaptiveAgent
+        from adaptive_agent.config import AgentConfig
+
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            session_dir = workspace / ".adaptive_agent" / "sessions"
+            session_dir.mkdir(parents=True)
+            old_id = "9" * 32
+            ts = (datetime.now(timezone.utc) - timedelta(days=60)).isoformat().replace("+00:00", "Z")
+            (session_dir / f"{old_id}.json").write_text(
+                json.dumps({"session_id": old_id, "status": "pending", "updated_at": ts}),
+                encoding="utf-8",
+            )
+
+            class _StubLLM:
+                def complete(self, _p):  # noqa: D401
+                    return "ok"
+
+            agent = AdaptiveAgent(
+                config=AgentConfig(
+                    workspace_dir=workspace,
+                    tool_library_dir=workspace / ".adaptive_agent" / "tools",
+                    session_dir=session_dir,
+                    session_cleanup_enabled=False,
+                ),
+                llm_client=_StubLLM(),
+            )
+
+            self.assertEqual(agent._cleanup_summary["deleted"], [])
+            self.assertTrue((session_dir / f"{old_id}.json").exists())
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## 요약

세션 디렉터리가 무한 누적되는 운영 리스크를 막기 위해 TTL 30일 + 카운트 100 cap 기반 자동 cleanup 도입.

## 관련 이슈

Closes #13

## 변경 사항

- \`SessionStore.cleanup_expired(max_age_days, max_count, now)\`:
  - \`updated_at\` 기준 TTL 초과 → 삭제 (\`reason=ttl\`)
  - 살아남은 항목 중 가장 오래된 것부터 cap 초과분 삭제 (\`reason=cap\`)
  - 잘못된 JSON / 누락 timestamp는 corrupt로 분류 후 삭제
  - pending 상태도 보호하지 않음 (오래된 HITL은 실제 garbage)
- \`AgentConfig\`에 \`session_cleanup_enabled\` / \`session_max_age_days\` / \`session_max_count\` 필드 + env override (\`ADAPTIVE_AGENT_SESSION_CLEANUP\`, \`_SESSION_MAX_AGE_DAYS\`, \`_SESSION_MAX_COUNT\`)
- \`AdaptiveAgent.__init__\`이 부팅 시 1회 cleanup 호출, 결과를 \`_cleanup_summary\`로 노출. OSError는 자력 startup 보장 위해 swallow

## 테스트

- [x] 빈 디렉터리 → no-op
- [x] TTL 경계: 45일 지난 세션 삭제, 10일 세션 유지
- [x] cap 경계: 5개 중 cap=2면 가장 오래된 3개 삭제
- [x] TTL이 cap보다 먼저 적용
- [x] 손상 JSON → corrupt 분류 후 삭제
- [x] 32-hex 패턴 안 맞는 파일은 손대지 않음
- [x] AdaptiveAgent enabled → cleanup 실행
- [x] AdaptiveAgent disabled → 미실행

\`\`\`
$ python -m unittest discover -s tests
Ran 133 tests in 0.850s — OK
\`\`\`

## Base

\`feature/agent-core-stabilization\` (PR #21). #21 머지 후 자동으로 main 기준 diff로 보입니다.