### PR TITLE
refactor(agents): extract execute_normalized_tool + retry loop into agents/executor (closes #15 Phase 1)

### DIFF
--- a/adaptive_agent/agent.py
+++ b/adaptive_agent/agent.py
@@ -6,6 +6,10 @@ import json
 from dataclasses import dataclass, field
 from typing import Any
 
+from adaptive_agent.agents import (
+    execute_normalized_tool as _execute_normalized_tool_helper,
+    run_self_correction_loop as _run_self_correction_loop_helper,
+)
 from adaptive_agent.config import AgentConfig
 from adaptive_agent.llms.base import LLMClient
 from adaptive_agent.llms.factory import create_llm_client
@@ -29,24 +33,6 @@ class AgentResponse:
     events: list[AgentEvent] = field(default_factory=list)
     session_id: str | None = None
     pending: dict[str, Any] | None = None
-
-
-@dataclass(frozen=True)
-class _ToolAttemptOutcome:
-    """One tool execution result + the data the retry loop needs to continue.
-
-    ``response`` is the terminal :class:`AgentResponse` (when success follow-up
-    short-circuited), or ``None`` when the router should keep going.
-    ``last_*`` fields capture the inputs/observations of this attempt and are
-    fed into the next correction prompt on failure.
-    """
-
-    success: bool
-    response: AgentResponse | None
-    last_plan: dict[str, Any]
-    last_error: str | None
-    last_output: Any
-    tool_name: str
 
 
 _VALID_PLAN_ACTIONS = {"tool", "respond"}
@@ -190,162 +176,22 @@ class AdaptiveAgent:
         plan: dict[str, Any],
         state: AgentState,
     ) -> AgentResponse | None:
-        """Execute a normalized tool plan with bounded self-correction.
+        """Thin facade over :mod:`adaptive_agent.agents.executor` helpers.
 
-        First attempt + (optional) bounded retry loop. Each individual tool
-        execution is delegated to :meth:`_execute_normalized_tool`; the retry
-        loop lives in :meth:`_run_self_correction_loop`.
+        The bounded execution + self-correction logic now lives in
+        ``agents/executor.py`` so the role boundary matches the router
+        diagram. This method is kept on the agent because router dependency
+        injection wires ``run_normalized_plan=self._run_normalized_plan``.
         """
 
         if plan.get("action") != "tool":
             return None
 
-        outcome = self._execute_normalized_tool(task, plan, state)
+        outcome = _execute_normalized_tool_helper(self, task, plan, state)
         if outcome.success:
             return outcome.response
 
-        return self._run_self_correction_loop(task=task, last_outcome=outcome, state=state)
-
-    def _execute_normalized_tool(
-        self,
-        task: str,
-        plan: dict[str, Any],
-        state: AgentState,
-        *,
-        retry_attempt: int | None = None,
-    ) -> "_ToolAttemptOutcome":
-        """Execute a single normalized ``tool`` plan and record events.
-
-        On success delegates follow-up routing to
-        :meth:`_handle_successful_tool_result`; the returned response is either
-        an :class:`AgentResponse` (terminal) or ``None`` (router continues).
-        """
-
-        tool_name = str(plan.get("tool_name") or "")
-        arguments = self._normalized_arguments(plan)
-        state.last_tool_name = tool_name
-        state.last_tool_arguments = dict(arguments)
-        code = arguments.get("code")
-        if isinstance(code, str):
-            state.generated_code = code
-        self._record_tool_spec(state, tool_name, arguments)
-        if retry_attempt is not None:
-            state.record_event("tool_reexecuted", tool_name=tool_name, attempt=retry_attempt)
-
-        result = self.run_tool(tool_name, arguments, _state=state)
-        state.last_tool_result = {
-            "success": result.success,
-            "output": result.output,
-            "error": result.error,
-        }
-        self._record_tool_result(state, tool_name, result.success, result.error)
-
-        normalized_plan = {"action": "tool", "tool_name": tool_name, "arguments": arguments}
-        if result.success:
-            response = self._handle_successful_tool_result(task, tool_name, result.output, state)
-            return _ToolAttemptOutcome(
-                success=True,
-                response=response,
-                last_plan=normalized_plan,
-                last_error=result.error,
-                last_output=result.output,
-                tool_name=tool_name,
-            )
-
-        state.failure_count += 1
-        state.error_log = str(result.error or "")
-        state.reflections.append(f"tool_execution_error:{tool_name}:{result.error}")
-        state.record_event("failure_classified", reason="tool_execution_error")
-        return _ToolAttemptOutcome(
-            success=False,
-            response=None,
-            last_plan=normalized_plan,
-            last_error=result.error,
-            last_output=result.output,
-            tool_name=tool_name,
-        )
-
-    def _run_self_correction_loop(
-        self,
-        *,
-        task: str,
-        last_outcome: "_ToolAttemptOutcome",
-        state: AgentState,
-    ) -> AgentResponse:
-        """Replan and re-execute up to ``max_self_corrections`` times.
-
-        Returns either a final ``tool_error`` response (loop exhausted or
-        provider failure) or the corrected plan's terminal response.
-        """
-
-        current_plan = last_outcome.last_plan
-        current_error = last_outcome.last_error
-        current_output = last_outcome.last_output
-        tool_name = last_outcome.tool_name
-
-        for attempt in range(1, self.config.max_self_corrections + 1):
-            state.record_event(
-                "self_correction_started",
-                attempt=attempt,
-                tool_name=tool_name,
-                error=current_error,
-            )
-            try:
-                corrected_plan = self._plan_correction_with_llm(
-                    task,
-                    current_plan,
-                    error=current_error,
-                    output=current_output,
-                )
-            except Exception as exc:
-                state.record_event("failure_classified", reason="external_provider_error")
-                current_error = f"LLM self-correction failed: {exc}"
-                break
-
-            validation_error = corrected_plan.pop("_validation_error", None)
-            if validation_error:
-                state.record_event("plan_validation_failed", reason=validation_error)
-            if corrected_plan.get("action") != "tool":
-                if corrected_plan.get("needs_user_input"):
-                    state.record_event(
-                        "clarification_requested",
-                        reason="self_correction_requested_user_input",
-                    )
-                state.record_event("final_response_created", action="llm")
-                return AgentResponse(
-                    task=task,
-                    output=corrected_plan.get("response", ""),
-                    action="llm",
-                    events=state.events,
-                )
-
-            outcome = self._execute_normalized_tool(
-                task,
-                corrected_plan,
-                state,
-                retry_attempt=attempt,
-            )
-            if outcome.success:
-                # Successful retry — return whatever follow-up routing produced
-                # (None means the router should continue, which the caller of
-                # ``_run_normalized_plan`` propagates faithfully).
-                return outcome.response  # type: ignore[return-value]
-
-            current_plan = outcome.last_plan
-            current_error = outcome.last_error
-            current_output = outcome.last_output
-            tool_name = outcome.tool_name
-
-        state.record_event("final_response_created", action="tool_error")
-        state.next_node = "error"
-        return AgentResponse(
-            task=task,
-            output=f"툴 실행 실패: {current_error}",
-            tool_name=tool_name,
-            action="tool_error",
-            events=state.events,
-            session_id=state.session_id,
-        )
+        return _run_self_correction_loop_helper(self, task=task, last_outcome=outcome, state=state)
 
     def _handle_successful_tool_result(
         self,

--- a/adaptive_agent/agents/__init__.py
+++ b/adaptive_agent/agents/__init__.py
@@ -3,7 +3,12 @@
 from adaptive_agent.agents.base import AgentResult, AgentRole, BaseRoleAgent
 from adaptive_agent.agents.coder import CoderAgent
 from adaptive_agent.agents.critic import CriticAgent
-from adaptive_agent.agents.executor import ExecutorAgent
+from adaptive_agent.agents.executor import (
+    ExecutorAgent,
+    ToolAttemptOutcome,
+    execute_normalized_tool,
+    run_self_correction_loop,
+)
 from adaptive_agent.agents.librarian import LibrarianAgent
 from adaptive_agent.agents.plan import PlanAgent
 
@@ -16,4 +21,7 @@ __all__ = [
     "ExecutorAgent",
     "LibrarianAgent",
     "PlanAgent",
+    "ToolAttemptOutcome",
+    "execute_normalized_tool",
+    "run_self_correction_loop",
 ]

--- a/adaptive_agent/agents/executor.py
+++ b/adaptive_agent/agents/executor.py
@@ -1,12 +1,27 @@
-"""Executor role agent implementation."""
+"""Executor role agent implementation.
+
+Phase 1 of #15: the bounded execution + self-correction logic moves out of
+``agent.py`` and lives next to the role agent that owns it. ``ExecutorAgent``
+itself remains a thin router-facing shim (so existing dependency-injection
+wiring is untouched), but the loop primitives (``ToolAttemptOutcome``,
+``execute_normalized_tool``, ``run_self_correction_loop``) are now module-level
+functions that take an ``agent`` reference.
+
+Phase 2-4 will keep tightening the boundary (move plan normalization and
+prompt builders out, slim ``agent.py`` toward a thin facade).
+"""
 
 from __future__ import annotations
 
 from collections.abc import Callable
-from typing import Any
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
 
 from adaptive_agent.agents.base import AgentResult, BaseRoleAgent
 from adaptive_agent.state import AgentState
+
+if TYPE_CHECKING:
+    from adaptive_agent.agent import AdaptiveAgent, AgentResponse
 
 
 class ExecutorAgent(BaseRoleAgent):
@@ -28,3 +43,165 @@ class ExecutorAgent(BaseRoleAgent):
             details["response"] = response
         state.record_event("agent_finished", agent_role=self.role, node=self.name, next_node=state.next_node)
         return AgentResult(next_node=state.next_node, details=details)
+
+
+@dataclass(frozen=True)
+class ToolAttemptOutcome:
+    """One tool execution result + the data the retry loop needs to continue.
+
+    ``response`` is the terminal :class:`AgentResponse` (when success follow-up
+    short-circuited), or ``None`` when the router should keep going.
+    ``last_*`` fields capture the inputs/observations of this attempt and are
+    fed into the next correction prompt on failure.
+    """
+
+    success: bool
+    response: "AgentResponse | None"
+    last_plan: dict[str, Any]
+    last_error: str | None
+    last_output: Any
+    tool_name: str
+
+
+def execute_normalized_tool(
+    agent: "AdaptiveAgent",
+    task: str,
+    plan: dict[str, Any],
+    state: AgentState,
+    *,
+    retry_attempt: int | None = None,
+) -> ToolAttemptOutcome:
+    """Execute a single normalized ``tool`` plan and record events.
+
+    On success delegates follow-up routing to
+    :meth:`AdaptiveAgent._handle_successful_tool_result`; the returned response
+    is either an :class:`AgentResponse` (terminal) or ``None`` (router
+    continues).
+    """
+
+    tool_name = str(plan.get("tool_name") or "")
+    arguments = agent._normalized_arguments(plan)
+    state.last_tool_name = tool_name
+    state.last_tool_arguments = dict(arguments)
+    code = arguments.get("code")
+    if isinstance(code, str):
+        state.generated_code = code
+    agent._record_tool_spec(state, tool_name, arguments)
+    if retry_attempt is not None:
+        state.record_event("tool_reexecuted", tool_name=tool_name, attempt=retry_attempt)
+
+    result = agent.run_tool(tool_name, arguments, _state=state)
+    state.last_tool_result = {
+        "success": result.success,
+        "output": result.output,
+        "error": result.error,
+    }
+    agent._record_tool_result(state, tool_name, result.success, result.error)
+
+    normalized_plan = {"action": "tool", "tool_name": tool_name, "arguments": arguments}
+    if result.success:
+        response = agent._handle_successful_tool_result(task, tool_name, result.output, state)
+        return ToolAttemptOutcome(
+            success=True,
+            response=response,
+            last_plan=normalized_plan,
+            last_error=result.error,
+            last_output=result.output,
+            tool_name=tool_name,
+        )
+
+    state.failure_count += 1
+    state.error_log = str(result.error or "")
+    state.reflections.append(f"tool_execution_error:{tool_name}:{result.error}")
+    state.record_event("failure_classified", reason="tool_execution_error")
+    return ToolAttemptOutcome(
+        success=False,
+        response=None,
+        last_plan=normalized_plan,
+        last_error=result.error,
+        last_output=result.output,
+        tool_name=tool_name,
+    )
+
+
+def run_self_correction_loop(
+    agent: "AdaptiveAgent",
+    *,
+    task: str,
+    last_outcome: ToolAttemptOutcome,
+    state: AgentState,
+) -> "AgentResponse":
+    """Replan and re-execute up to ``max_self_corrections`` times.
+
+    Returns either a final ``tool_error`` response (loop exhausted or
+    provider failure) or the corrected plan's terminal response.
+    """
+
+    from adaptive_agent.agent import AgentResponse  # avoid circular import at module load
+
+    current_plan = last_outcome.last_plan
+    current_error = last_outcome.last_error
+    current_output = last_outcome.last_output
+    tool_name = last_outcome.tool_name
+
+    for attempt in range(1, agent.config.max_self_corrections + 1):
+        state.record_event(
+            "self_correction_started",
+            attempt=attempt,
+            tool_name=tool_name,
+            error=current_error,
+        )
+        try:
+            corrected_plan = agent._plan_correction_with_llm(
+                task,
+                current_plan,
+                error=current_error,
+                output=current_output,
+            )
+        except Exception as exc:
+            state.record_event("failure_classified", reason="external_provider_error")
+            current_error = f"LLM self-correction failed: {exc}"
+            break
+
+        validation_error = corrected_plan.pop("_validation_error", None)
+        if validation_error:
+            state.record_event("plan_validation_failed", reason=validation_error)
+        if corrected_plan.get("action") != "tool":
+            if corrected_plan.get("needs_user_input"):
+                state.record_event(
+                    "clarification_requested",
+                    reason="self_correction_requested_user_input",
+                )
+            state.record_event("final_response_created", action="llm")
+            return AgentResponse(
+                task=task,
+                output=corrected_plan.get("response", ""),
+                action="llm",
+                events=state.events,
+            )
+
+        outcome = execute_normalized_tool(
+            agent,
+            task,
+            corrected_plan,
+            state,
+            retry_attempt=attempt,
+        )
+        if outcome.success:
+            return outcome.response  # type: ignore[return-value]
+
+        current_plan = outcome.last_plan
+        current_error = outcome.last_error
+        current_output = outcome.last_output
+        tool_name = outcome.tool_name
+
+    state.record_event("final_response_created", action="tool_error")
+    state.next_node = "error"
+    return AgentResponse(
+        task=task,
+        output=f"툴 실행 실패: {current_error}",
+        tool_name=tool_name,
+        action="tool_error",
+        events=state.events,
+        session_id=state.session_id,
+    )


### PR DESCRIPTION
## 요약

\`_run_normalized_plan\`의 첫 번째 분해(#21에서 시작) 결과인 헬퍼 함수들을 \`adaptive_agent/agents/executor.py\`로 이동. 모듈 경계가 라우터 다이어그램과 1:1 대응.

## 관련 이슈

Closes #15 (Phase 1만)

## 변경 사항

- \`agents/executor.py\`에 추가:
  - \`ToolAttemptOutcome\` (이전 \`_ToolAttemptOutcome\`, public)
  - \`execute_normalized_tool(agent, task, plan, state, *, retry_attempt=None)\`
  - \`run_self_correction_loop(agent, *, task, last_outcome, state)\`
- \`ExecutorAgent\` 클래스는 변경 없음 (라우터 shim 유지)
- \`agent.py::_run_normalized_plan\`이 13줄 thin facade로 축소
- \`agents/__init__.py\` 재export

## 비범위 (Phase 2-4)

- plan normalization (\`_normalize_plan\` 등)을 \`agents/plan.py\` 또는 \`plan_normalizer.py\`로
- prompt builders (\`_build_*_prompt\`)를 \`prompts/builders.py\`로
- JSON 파서 (\`_loads_plan_json\`)를 utils로
- \`agent.py\` ~870줄 → ~300줄 facade

## 테스트

- [x] 기능 변화 없음 (delegating refactor)
- [x] 125 tests 모두 통과 (회귀 0)
- [x] PR #21 + #15 = 라우터 다이어그램의 ExecutorAgent 모듈 경계와 코드 위치 일치

\`\`\`
$ python -m unittest discover -s tests
Ran 125 tests in 0.956s — OK
\`\`\`

## Base

\`feature/agent-core-stabilization\` (PR #21).