### PR TITLE
feat(tools): add artifact_store and web_fetch builtins (closes #19)

### DIFF
--- a/adaptive_agent/agent.py
+++ b/adaptive_agent/agent.py
@@ -80,6 +80,11 @@ class AdaptiveAgent:
         self.registry = registry or create_default_registry(
             self.config.workspace_dir,
             tool_library_dir=self.config.tool_library_dir,
+            artifact_max_bytes=self.config.artifact_max_bytes,
+            artifact_max_count=self.config.artifact_max_count,
+            web_fetch_allowed_domains=self.config.web_fetch_allowed_domains,
+            web_fetch_max_bytes=self.config.web_fetch_max_bytes,
+            web_fetch_timeout_seconds=self.config.web_fetch_timeout_seconds,
         )
         self.executor = executor or ToolExecutor(self.registry)
         self.prompt_loader = prompt_loader or PromptLoader()

--- a/adaptive_agent/config.py
+++ b/adaptive_agent/config.py
@@ -32,6 +32,11 @@ class AgentConfig:
     session_dir: Path = Path.cwd() / ".adaptive_agent" / "sessions"
     max_self_corrections: int = 2
     max_router_steps: int = 8
+    artifact_max_bytes: int = 10 * 1024 * 1024
+    artifact_max_count: int = 1000
+    web_fetch_allowed_domains: tuple[str, ...] = ()
+    web_fetch_max_bytes: int = 1024 * 1024
+    web_fetch_timeout_seconds: float = 10.0
     ollama_timeout_seconds: float = 60.0
     ollama_num_predict: int = 256
     ollama_think: bool = False
@@ -79,6 +84,15 @@ class AgentConfig:
             session_dir=session_dir,
             max_self_corrections=int(os.getenv("ADAPTIVE_AGENT_MAX_SELF_CORRECTIONS", "2")),
             max_router_steps=int(os.getenv("ADAPTIVE_AGENT_MAX_ROUTER_STEPS", "8")),
+            artifact_max_bytes=int(os.getenv("ADAPTIVE_AGENT_ARTIFACT_MAX_BYTES", str(10 * 1024 * 1024))),
+            artifact_max_count=int(os.getenv("ADAPTIVE_AGENT_ARTIFACT_MAX_COUNT", "1000")),
+            web_fetch_allowed_domains=tuple(
+                d.strip()
+                for d in os.getenv("ADAPTIVE_AGENT_WEB_FETCH_ALLOWED_DOMAINS", "").split(",")
+                if d.strip()
+            ),
+            web_fetch_max_bytes=int(os.getenv("ADAPTIVE_AGENT_WEB_FETCH_MAX_BYTES", str(1024 * 1024))),
+            web_fetch_timeout_seconds=float(os.getenv("ADAPTIVE_AGENT_WEB_FETCH_TIMEOUT_SECONDS", "10")),
             ollama_timeout_seconds=float(os.getenv("OLLAMA_TIMEOUT_SECONDS", "60")),
             ollama_num_predict=int(os.getenv("OLLAMA_NUM_PREDICT", "256")),
             ollama_think=os.getenv("OLLAMA_THINK", "false").strip().lower() in {"1", "true", "yes", "on"},

--- a/adaptive_agent/tools/builtins.py
+++ b/adaptive_agent/tools/builtins.py
@@ -483,19 +483,311 @@ def memory_write(arguments: dict[str, object], *, memory_dir: Path) -> ToolExecu
 def suggested_builtin_tools(_arguments: dict[str, object]) -> ToolExecutionResult:
     """Return candidate builtin tools for future core expansion."""
 
+    # artifact_store / web_fetch는 이제 실제 핸들러로 등록되었지만, 후보
+    # 목록은 향후 확장 가이드를 위해 유지한다 (artifact_search, mcp_bridge 등).
     return ToolExecutionResult(
         success=True,
         output=[
             {
-                "name": "artifact_store",
-                "reason": "실행 로그, diff, 생성 파일을 PR/리포트에 연결할 수 있는 산출물 저장 계층이 필요합니다.",
+                "name": "artifact_search",
+                "reason": "저장된 artifact를 query/태그로 검색하는 보조 도구가 필요합니다.",
             },
             {
-                "name": "web_fetch",
-                "reason": "공식 문서 확인이 필요한 구현에서 네트워크 조회를 명시적인 도구로 분리할 수 있습니다.",
+                "name": "mcp_bridge",
+                "reason": "외부 MCP 서버의 도구를 동적 등록할 수 있는 어댑터가 필요합니다.",
             },
         ],
     )
+
+
+_ARTIFACT_OPS = {"put", "get", "list", "delete"}
+_ARTIFACT_DIRNAME = ".adaptive_agent/artifacts"
+
+
+def artifact_store(
+    arguments: dict[str, object],
+    *,
+    workspace: Path,
+    max_bytes: int = 10 * 1024 * 1024,
+    max_count: int = 1000,
+) -> ToolExecutionResult:
+    """Persist binary/text artifacts under the workspace with sha256 IDs.
+
+    Supported ops:
+
+    - ``put``: write bytes (or base64-encoded ``content_base64`` /
+      utf8 ``content``) and return ``{artifact_id, sha256, bytes_written, path}``.
+    - ``get``: read by ``artifact_id``; returns ``{artifact_id, mime_type,
+      content_base64, bytes}``.
+    - ``list``: enumerate stored artifacts with metadata.
+    - ``delete``: remove by ``artifact_id``.
+
+    Each artifact is stored as ``<workspace>/.adaptive_agent/artifacts/<sha256>.bin``
+    plus a sibling ``.json`` with ``{name, mime_type, sha256, bytes, created_at}``.
+    """
+
+    op = str(arguments.get("op") or "put").lower()
+    if op not in _ARTIFACT_OPS:
+        return ToolExecutionResult(success=False, output="", error=f"지원하지 않는 op입니다: {op} (지원: {sorted(_ARTIFACT_OPS)})")
+
+    artifacts_dir = (workspace / _ARTIFACT_DIRNAME).resolve()
+    artifacts_dir.mkdir(parents=True, exist_ok=True)
+
+    if op == "put":
+        return _artifact_put(arguments, artifacts_dir=artifacts_dir, max_bytes=max_bytes, max_count=max_count)
+    if op == "get":
+        return _artifact_get(arguments, artifacts_dir=artifacts_dir)
+    if op == "list":
+        return _artifact_list(artifacts_dir=artifacts_dir, prefix=str(arguments.get("prefix") or ""))
+    return _artifact_delete(arguments, artifacts_dir=artifacts_dir)
+
+
+def _artifact_put(
+    arguments: dict[str, object],
+    *,
+    artifacts_dir: Path,
+    max_bytes: int,
+    max_count: int,
+) -> ToolExecutionResult:
+    import base64
+
+    name = str(arguments.get("name") or "")
+    if not name or "/" in name or ".." in name:
+        return ToolExecutionResult(success=False, output="", error="name은 디렉터리 구분자/.. 없는 단일 토큰이어야 합니다.")
+    mime_type = str(arguments.get("mime_type") or "application/octet-stream")
+
+    raw_content = arguments.get("content")
+    raw_b64 = arguments.get("content_base64")
+    if raw_b64 is not None:
+        try:
+            payload = base64.b64decode(str(raw_b64), validate=True)
+        except (ValueError, base64.binascii.Error) as exc:
+            return ToolExecutionResult(success=False, output="", error=f"content_base64 디코드 실패: {exc}")
+    elif isinstance(raw_content, (str, bytes)):
+        payload = raw_content.encode("utf-8") if isinstance(raw_content, str) else raw_content
+    else:
+        return ToolExecutionResult(success=False, output="", error="content 또는 content_base64 인자가 필요합니다.")
+
+    if len(payload) > max_bytes:
+        return ToolExecutionResult(
+            success=False,
+            output={"max_bytes": max_bytes, "actual_bytes": len(payload)},
+            error=f"artifact 크기가 한도를 초과했습니다: {len(payload)} > {max_bytes}",
+        )
+
+    existing = list(artifacts_dir.glob("*.bin"))
+    if len(existing) >= max_count:
+        return ToolExecutionResult(
+            success=False,
+            output={"max_count": max_count, "current_count": len(existing)},
+            error=f"artifact 개수 한도를 초과했습니다: {len(existing)} >= {max_count}",
+        )
+
+    sha = hashlib.sha256(payload).hexdigest()
+    bin_path = artifacts_dir / f"{sha}.bin"
+    meta_path = artifacts_dir / f"{sha}.json"
+    bin_path.write_bytes(payload)
+    metadata = {
+        "name": name,
+        "mime_type": mime_type,
+        "sha256": sha,
+        "bytes": len(payload),
+        "created_at": _utc_now_iso(),
+    }
+    meta_path.write_text(json.dumps(metadata, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    return ToolExecutionResult(
+        success=True,
+        output={
+            "artifact_id": sha,
+            "sha256": sha,
+            "bytes_written": len(payload),
+            "path": str(bin_path),
+            "name": name,
+        },
+    )
+
+
+def _artifact_get(arguments: dict[str, object], *, artifacts_dir: Path) -> ToolExecutionResult:
+    import base64
+
+    artifact_id = str(arguments.get("artifact_id") or "")
+    if not re.fullmatch(r"[a-f0-9]{64}", artifact_id):
+        return ToolExecutionResult(success=False, output="", error="artifact_id는 64자 hex여야 합니다.")
+    bin_path = artifacts_dir / f"{artifact_id}.bin"
+    meta_path = artifacts_dir / f"{artifact_id}.json"
+    if not bin_path.exists() or not meta_path.exists():
+        return ToolExecutionResult(success=False, output="", error=f"artifact를 찾을 수 없습니다: {artifact_id}")
+    metadata = _read_json_object(meta_path)
+    payload = bin_path.read_bytes()
+    return ToolExecutionResult(
+        success=True,
+        output={
+            "artifact_id": artifact_id,
+            "name": metadata.get("name", ""),
+            "mime_type": metadata.get("mime_type", "application/octet-stream"),
+            "bytes": len(payload),
+            "content_base64": base64.b64encode(payload).decode("ascii"),
+        },
+    )
+
+
+def _artifact_list(*, artifacts_dir: Path, prefix: str) -> ToolExecutionResult:
+    entries: list[dict[str, object]] = []
+    for meta_path in sorted(artifacts_dir.glob("*.json")):
+        metadata = _read_json_object(meta_path)
+        if prefix and not str(metadata.get("name", "")).startswith(prefix):
+            continue
+        entries.append(
+            {
+                "artifact_id": meta_path.stem,
+                "name": metadata.get("name", ""),
+                "mime_type": metadata.get("mime_type", ""),
+                "bytes": metadata.get("bytes", 0),
+                "created_at": metadata.get("created_at", ""),
+            }
+        )
+    return ToolExecutionResult(success=True, output={"entries": entries, "count": len(entries)})
+
+
+def _artifact_delete(arguments: dict[str, object], *, artifacts_dir: Path) -> ToolExecutionResult:
+    artifact_id = str(arguments.get("artifact_id") or "")
+    if not re.fullmatch(r"[a-f0-9]{64}", artifact_id):
+        return ToolExecutionResult(success=False, output="", error="artifact_id는 64자 hex여야 합니다.")
+    bin_path = artifacts_dir / f"{artifact_id}.bin"
+    meta_path = artifacts_dir / f"{artifact_id}.json"
+    deleted = False
+    if bin_path.exists():
+        bin_path.unlink()
+        deleted = True
+    if meta_path.exists():
+        meta_path.unlink()
+        deleted = True
+    if not deleted:
+        return ToolExecutionResult(success=False, output="", error=f"삭제할 artifact를 찾을 수 없습니다: {artifact_id}")
+    return ToolExecutionResult(success=True, output={"artifact_id": artifact_id, "deleted": True})
+
+
+def _utc_now_iso() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def web_fetch(
+    arguments: dict[str, object],
+    *,
+    allowed_domains: list[str] | None = None,
+    max_bytes: int = 1024 * 1024,
+    timeout_seconds: float = 10.0,
+) -> ToolExecutionResult:
+    """Fetch a URL with a strict domain whitelist (default deny).
+
+    Decision (issue #19): use ``urllib.request`` from stdlib instead of
+    httpx so this builtin works without adding a dependency. Behavior is
+    equivalent for the supported scope (GET/POST, JSON/text body, custom
+    headers, redirect handling, byte cap).
+
+    Block reason ``domain_not_allowlisted`` is surfaced in the verdict for
+    machine-readable rejection (matches the policy enum spirit of #21).
+    """
+
+    import time as _time
+    import urllib.error
+    import urllib.parse
+    import urllib.request
+
+    url = str(arguments.get("url") or "")
+    if not url:
+        return ToolExecutionResult(success=False, output="", error="url 인자가 필요합니다.")
+
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme not in {"http", "https"}:
+        return ToolExecutionResult(success=False, output="", error=f"지원하지 않는 scheme: {parsed.scheme}")
+    host = (parsed.hostname or "").lower()
+    if not host:
+        return ToolExecutionResult(success=False, output="", error="URL에서 host를 추출할 수 없습니다.")
+
+    allowed = [d.strip().lower() for d in (allowed_domains or []) if d.strip()]
+    if not _domain_in_allowlist(host, allowed):
+        return ToolExecutionResult(
+            success=False,
+            output={
+                "verdict": {
+                    "policy_blocked": True,
+                    "block_reason": "domain_not_allowlisted",
+                    "host": host,
+                    "allowed": allowed,
+                }
+            },
+            error=f"도메인이 화이트리스트에 없습니다: {host}",
+        )
+
+    method = str(arguments.get("method") or "GET").upper()
+    headers_raw = arguments.get("headers") or {}
+    headers = {str(k): str(v) for k, v in headers_raw.items()} if isinstance(headers_raw, dict) else {}
+    body_raw = arguments.get("body")
+    body_bytes: bytes | None = None
+    if body_raw is not None:
+        body_bytes = body_raw.encode("utf-8") if isinstance(body_raw, str) else json.dumps(body_raw).encode("utf-8")
+
+    request = urllib.request.Request(url, data=body_bytes, method=method, headers=headers)
+    started = _time.monotonic()
+    try:
+        with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+            payload = response.read(max_bytes + 1)
+            truncated = len(payload) > max_bytes
+            payload = payload[:max_bytes]
+            elapsed_ms = int((_time.monotonic() - started) * 1000)
+            response_headers = {k: v for k, v in response.headers.items()}
+            try:
+                body_text = payload.decode("utf-8")
+                body_truncated_text = truncated
+            except UnicodeDecodeError:
+                import base64
+
+                body_text = base64.b64encode(payload).decode("ascii")
+                body_truncated_text = truncated
+            return ToolExecutionResult(
+                success=True,
+                output={
+                    "status_code": response.status,
+                    "headers": response_headers,
+                    "body_text": body_text,
+                    "body_truncated": body_truncated_text,
+                    "bytes_read": len(payload),
+                    "elapsed_ms": elapsed_ms,
+                    "host": host,
+                },
+            )
+    except urllib.error.HTTPError as exc:
+        elapsed_ms = int((_time.monotonic() - started) * 1000)
+        return ToolExecutionResult(
+            success=False,
+            output={
+                "status_code": exc.code,
+                "host": host,
+                "elapsed_ms": elapsed_ms,
+            },
+            error=f"HTTP 오류: {exc.code} {exc.reason}",
+        )
+    except urllib.error.URLError as exc:
+        return ToolExecutionResult(success=False, output={"host": host}, error=f"네트워크 오류: {exc.reason}")
+    except (TimeoutError, OSError) as exc:
+        return ToolExecutionResult(success=False, output={"host": host}, error=f"네트워크 호출 실패: {exc}")
+
+
+def _domain_in_allowlist(host: str, allowed: list[str]) -> bool:
+    """Return True if host matches any allowed entry (exact or subdomain)."""
+
+    if not allowed:
+        return False
+    for entry in allowed:
+        if not entry:
+            continue
+        if host == entry or host.endswith("." + entry):
+            return True
+    return False
 
 
 def _result_from_process(process_output: dict[str, object], arguments: dict[str, object]) -> ToolExecutionResult:

--- a/adaptive_agent/tools/registry.py
+++ b/adaptive_agent/tools/registry.py
@@ -33,6 +33,12 @@ class ToolRegistry:
 def create_default_registry(
     workspace_dir: Path | None = None,
     tool_library_dir: Path | None = None,
+    *,
+    artifact_max_bytes: int = 10 * 1024 * 1024,
+    artifact_max_count: int = 1000,
+    web_fetch_allowed_domains: tuple[str, ...] | list[str] = (),
+    web_fetch_max_bytes: int = 1024 * 1024,
+    web_fetch_timeout_seconds: float = 10.0,
 ) -> ToolRegistry:
     """Create the default builtin tool registry."""
 
@@ -42,6 +48,7 @@ def create_default_registry(
     tool_library = (tool_library_dir or workspace / ".adaptive_agent" / "tools").resolve()
     memory_dir = workspace / ".adaptive_agent" / "memory"
     sandbox = LocalSandboxBackend(raw_workspace)
+    web_fetch_allowed = list(web_fetch_allowed_domains)
 
     def echo(arguments: dict[str, object]) -> ToolExecutionResult:
         return ToolExecutionResult(success=True, output=arguments.get("task", ""))
@@ -297,6 +304,36 @@ def create_default_registry(
             category="planning",
             safety_level="low",
             usage="python3 -m adaptive_agent --tool suggest_builtin_tools",
+        )
+    )
+    registry.register(
+        Tool(
+            name="artifact_store",
+            description="실행 산출물(파일/diff/로그)을 sha256 ID로 워크스페이스에 저장하고 조회합니다.",
+            handler=lambda arguments: builtins.artifact_store(
+                arguments,
+                workspace=workspace,
+                max_bytes=artifact_max_bytes,
+                max_count=artifact_max_count,
+            ),
+            category="filesystem",
+            safety_level="medium",
+            usage='python3 -m adaptive_agent --json --tool artifact_store --arg op=put --arg name=log.txt --arg content=hello',
+        )
+    )
+    registry.register(
+        Tool(
+            name="web_fetch",
+            description="화이트리스트된 도메인에 한해 HTTP(S) 요청을 보내고 응답을 반환합니다.",
+            handler=lambda arguments: builtins.web_fetch(
+                arguments,
+                allowed_domains=web_fetch_allowed,
+                max_bytes=web_fetch_max_bytes,
+                timeout_seconds=web_fetch_timeout_seconds,
+            ),
+            category="execution",
+            safety_level="high",
+            usage='python3 -m adaptive_agent --json --tool web_fetch --arg url=https://example.com',
         )
     )
     registry.generated_load_results = load_generated_tools(registry, tool_library=tool_library, sandbox=sandbox)

--- a/tests/test_artifact_and_web_fetch.py
+++ b/tests/test_artifact_and_web_fetch.py
@@ -1,0 +1,249 @@
+"""artifact_store + web_fetch 내장 도구 테스트.
+
+#19 — 신규 builtin 두 종류:
+- artifact_store: put/get/list/delete + sha256 ID + 크기/개수 한도
+- web_fetch: 화이트리스트 도메인만 허용, max_bytes/timeout 기본값
+"""
+
+from __future__ import annotations
+
+import base64
+import json
+import socket
+import tempfile
+import threading
+import unittest
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+from adaptive_agent.tools import builtins
+from adaptive_agent.tools.registry import create_default_registry
+
+
+class ArtifactStoreTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _put(self, **kwargs):
+        return builtins.artifact_store({"op": "put", **kwargs}, workspace=self.workspace)
+
+    def test_put_then_get_round_trip_text(self) -> None:
+        put = self._put(name="hello.txt", content="안녕 world", mime_type="text/plain")
+        self.assertTrue(put.success, put.error)
+        sha = put.output["artifact_id"]
+
+        got = builtins.artifact_store({"op": "get", "artifact_id": sha}, workspace=self.workspace)
+        self.assertTrue(got.success, got.error)
+        decoded = base64.b64decode(got.output["content_base64"]).decode("utf-8")
+        self.assertEqual(decoded, "안녕 world")
+        self.assertEqual(got.output["mime_type"], "text/plain")
+
+    def test_put_with_base64_content(self) -> None:
+        binary = bytes(range(256))
+        encoded = base64.b64encode(binary).decode("ascii")
+        put = self._put(name="bin.dat", content_base64=encoded, mime_type="application/octet-stream")
+        self.assertTrue(put.success, put.error)
+
+        got = builtins.artifact_store({"op": "get", "artifact_id": put.output["artifact_id"]}, workspace=self.workspace)
+        self.assertTrue(got.success)
+        self.assertEqual(base64.b64decode(got.output["content_base64"]), binary)
+
+    def test_list_returns_stored_entries(self) -> None:
+        self._put(name="a.txt", content="hi a")
+        self._put(name="b.txt", content="hi b")
+        self._put(name="c.bin", content="hi c")
+
+        listed = builtins.artifact_store({"op": "list"}, workspace=self.workspace)
+        self.assertTrue(listed.success)
+        names = {entry["name"] for entry in listed.output["entries"]}
+        self.assertEqual(names, {"a.txt", "b.txt", "c.bin"})
+
+    def test_list_with_prefix_filters(self) -> None:
+        self._put(name="prod-001.log", content="prod-001-content")
+        self._put(name="prod-002.log", content="prod-002-content")
+        self._put(name="dev-001.log", content="dev-001-content")
+        listed = builtins.artifact_store({"op": "list", "prefix": "prod-"}, workspace=self.workspace)
+
+        self.assertTrue(listed.success)
+        names = {entry["name"] for entry in listed.output["entries"]}
+        self.assertEqual(names, {"prod-001.log", "prod-002.log"})
+
+    def test_delete_removes_artifact(self) -> None:
+        put = self._put(name="ephemeral.txt", content="bye")
+        sha = put.output["artifact_id"]
+        artifacts_dir = self.workspace / ".adaptive_agent" / "artifacts"
+        self.assertTrue((artifacts_dir / f"{sha}.bin").exists())
+
+        deleted = builtins.artifact_store({"op": "delete", "artifact_id": sha}, workspace=self.workspace)
+        self.assertTrue(deleted.success)
+        self.assertFalse((artifacts_dir / f"{sha}.bin").exists())
+
+    def test_max_bytes_blocks_oversized_payload(self) -> None:
+        result = builtins.artifact_store(
+            {"op": "put", "name": "big.bin", "content": "x" * 200},
+            workspace=self.workspace,
+            max_bytes=100,
+        )
+        self.assertFalse(result.success)
+        self.assertIn("한도", result.error)
+
+    def test_max_count_blocks_when_full(self) -> None:
+        for i in range(2):
+            r = builtins.artifact_store(
+                {"op": "put", "name": f"x{i}.txt", "content": str(i)},
+                workspace=self.workspace,
+                max_count=2,
+            )
+            self.assertTrue(r.success)
+        full = builtins.artifact_store(
+            {"op": "put", "name": "overflow.txt", "content": "no"},
+            workspace=self.workspace,
+            max_count=2,
+        )
+        self.assertFalse(full.success)
+        self.assertIn("개수 한도", full.error)
+
+    def test_invalid_op_is_rejected(self) -> None:
+        result = builtins.artifact_store({"op": "evil"}, workspace=self.workspace)
+        self.assertFalse(result.success)
+        self.assertIn("지원하지 않는 op", result.error)
+
+    def test_get_with_invalid_artifact_id_is_rejected(self) -> None:
+        result = builtins.artifact_store({"op": "get", "artifact_id": "not-hex"}, workspace=self.workspace)
+        self.assertFalse(result.success)
+        self.assertIn("64자 hex", result.error)
+
+    def test_name_with_path_traversal_is_rejected(self) -> None:
+        for bad in ("../escape", "sub/dir.txt", ".."):
+            with self.subTest(name=bad):
+                result = self._put(name=bad, content="x")
+                self.assertFalse(result.success)
+                self.assertIn("디렉터리", result.error)
+
+    def test_artifact_store_is_registered_in_default_registry(self) -> None:
+        registry = create_default_registry(self.workspace)
+        tool = registry.get("artifact_store")
+        self.assertIsNotNone(tool)
+        self.assertEqual(tool.category, "filesystem")
+
+
+class WebFetchPolicyTest(unittest.TestCase):
+    def test_blocks_when_allowlist_empty(self) -> None:
+        result = builtins.web_fetch(
+            {"url": "https://example.com"},
+            allowed_domains=[],
+        )
+        self.assertFalse(result.success)
+        verdict = result.output["verdict"]
+        self.assertTrue(verdict["policy_blocked"])
+        self.assertEqual(verdict["block_reason"], "domain_not_allowlisted")
+        self.assertEqual(verdict["host"], "example.com")
+
+    def test_blocks_unlisted_domain(self) -> None:
+        result = builtins.web_fetch(
+            {"url": "https://malicious.example.com"},
+            allowed_domains=["api.openai.com"],
+        )
+        self.assertFalse(result.success)
+        self.assertEqual(result.output["verdict"]["block_reason"], "domain_not_allowlisted")
+
+    def test_allowed_subdomain_passes_policy_check(self) -> None:
+        # 실제 fetch는 안 되더라도(네트워크 없음) 정책 단계는 통과해야 함.
+        # 여기서는 host 매칭 로직만 검증한다.
+        from adaptive_agent.tools.builtins import _domain_in_allowlist
+
+        self.assertTrue(_domain_in_allowlist("api.openai.com", ["openai.com"]))
+        self.assertTrue(_domain_in_allowlist("openai.com", ["openai.com"]))
+        self.assertFalse(_domain_in_allowlist("evil-openai.com", ["openai.com"]))
+        self.assertFalse(_domain_in_allowlist("openai.com.evil", ["openai.com"]))
+
+    def test_unsupported_scheme_is_rejected(self) -> None:
+        result = builtins.web_fetch(
+            {"url": "file:///etc/passwd"},
+            allowed_domains=["openai.com"],
+        )
+        self.assertFalse(result.success)
+        self.assertIn("scheme", result.error)
+
+    def test_url_required(self) -> None:
+        result = builtins.web_fetch({}, allowed_domains=["x"])
+        self.assertFalse(result.success)
+        self.assertIn("url", result.error)
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def do_GET(self):  # noqa: N802
+        if self.path == "/ok":
+            body = b"hello world"
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        elif self.path == "/big":
+            body = b"x" * 5_000
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_error(404, "not found")
+
+    def log_message(self, *args, **kwargs):  # silence test logs
+        return
+
+
+class WebFetchHTTPTest(unittest.TestCase):
+    """Loopback HTTP server로 실제 fetch까지 검증."""
+
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.server = HTTPServer(("127.0.0.1", 0), _Handler)
+        cls.port = cls.server.server_address[1]
+        cls.thread = threading.Thread(target=cls.server.serve_forever, daemon=True)
+        cls.thread.start()
+
+    @classmethod
+    def tearDownClass(cls) -> None:
+        cls.server.shutdown()
+        cls.server.server_close()
+
+    def test_get_succeeds_when_loopback_allowed(self) -> None:
+        result = builtins.web_fetch(
+            {"url": f"http://127.0.0.1:{self.port}/ok"},
+            allowed_domains=["127.0.0.1"],
+            timeout_seconds=2.0,
+        )
+        self.assertTrue(result.success, result.error)
+        self.assertEqual(result.output["status_code"], 200)
+        self.assertIn("hello world", result.output["body_text"])
+        self.assertFalse(result.output["body_truncated"])
+
+    def test_max_bytes_truncates_body(self) -> None:
+        result = builtins.web_fetch(
+            {"url": f"http://127.0.0.1:{self.port}/big"},
+            allowed_domains=["127.0.0.1"],
+            max_bytes=1000,
+            timeout_seconds=2.0,
+        )
+        self.assertTrue(result.success)
+        self.assertEqual(result.output["bytes_read"], 1000)
+        self.assertTrue(result.output["body_truncated"])
+
+    def test_404_returns_failure_with_status_code(self) -> None:
+        result = builtins.web_fetch(
+            {"url": f"http://127.0.0.1:{self.port}/missing"},
+            allowed_domains=["127.0.0.1"],
+            timeout_seconds=2.0,
+        )
+        self.assertFalse(result.success)
+        self.assertEqual(result.output["status_code"], 404)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_builtin_tools.py
+++ b/tests/test_builtin_tools.py
@@ -502,12 +502,16 @@ class BuiltinToolsTest(unittest.TestCase):
         self.assertEqual(read_result.output["value"], "한국어")
 
     def test_suggest_builtin_tools_includes_remaining_candidates(self) -> None:
+        # artifact_store / web_fetch는 이제 실제 builtin이라 후보 목록에서 빠지고
+        # 다음 확장 후보(artifact_search / mcp_bridge)로 교체됨.
         result = self.run_tool("suggest_builtin_tools", {})
 
         self.assertTrue(result.success)
         names = {candidate["name"] for candidate in result.output}
-        self.assertIn("artifact_store", names)
-        self.assertIn("web_fetch", names)
+        self.assertGreater(len(names), 0, "최소 한 개의 후보가 있어야 함")
+        # 이미 구현된 도구는 후보로 다시 노출되면 안 됨
+        registered = {tool.name for tool in self.registry.list()}
+        self.assertFalse(names & registered, "이미 등록된 도구는 후보에 들어가지 않아야 함")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 요약

\`suggest_builtin_tools\`가 후보로만 노출하던 \`artifact_store\`와 \`web_fetch\`를 실제 builtin으로 등록.

## 관련 이슈

Closes #19

## 변경 사항

**artifact_store**: ops = \`put\`/\`get\`/\`list\`/\`delete\`. sha256을 ID로. \`workspace/.adaptive_agent/artifacts/<sha>.bin\` + \`.json\` 메타. 한도 10MB/1000개 기본.

**web_fetch**: 화이트리스트 도메인만 허용 (default deny). \`urllib.request\` 사용으로 dep 추가 없이 stdlib만으로 구현. 한도 1MB/10초 기본. 차단 시 \`verdict.block_reason='domain_not_allowlisted'\` (#21 정책 enum 일관).

**config**: \`artifact_max_bytes\`/\`_count\`, \`web_fetch_allowed_domains\` (tuple) / \`_max_bytes\` / \`_timeout_seconds\` 추가 + env override 지원.

## 결정 (이슈와 다른 부분)

- httpx 대신 \`urllib.request\` 사용 — 외부 의존성 추가를 피해 zero-dep 동작 유지. 동일 기능 (GET/POST/redirect/timeout/byte cap) 모두 커버됨.

## 테스트 (19 신규)

- [x] artifact put/get round-trip (text + base64 binary)
- [x] list 전체 / prefix 필터
- [x] delete 동작 + 파일 시스템 검증
- [x] max_bytes/max_count 한도 차단 (구체 메시지)
- [x] invalid op / 잘못된 sha 형식 / path traversal 차단
- [x] registry에 \`artifact_store\` 등록 검증
- [x] web_fetch 정책: 빈/비-화이트리스트/서브도메인/file:// 스킴/url 누락
- [x] web_fetch HTTP: loopback 서버로 200 ok / max_bytes truncate / 404

\`\`\`
$ python -m unittest discover -s tests
Ran 144 tests in 1.423s — OK
\`\`\`

## Base

\`feature/agent-core-stabilization\` (PR #21).