### PR TITLE
build(packaging): add pyproject.toml + adaptive-agent console entry point

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,11 +59,26 @@ tests/
 
 ## 설치 및 환경 설정
 
+가장 간단한 설치 (소스에서 editable):
+
 ```bash
 python3 -m venv .venv
 source .venv/bin/activate
-pip install -r requirements.txt
+pip install -e .
 cp .env.example .env
+```
+
+설치 후엔 `python -m adaptive_agent ...` 외에 짧은 콘솔 진입점도 사용 가능합니다:
+
+```bash
+adaptive-agent --list-tools
+adaptive-agent --tool echo --arg task=hello
+```
+
+기존 방식(requirements.txt 직접 설치)도 그대로 동작합니다:
+
+```bash
+pip install -r requirements.txt
 ```
 
 ## Validation Scenarios

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,55 @@
+[build-system]
+requires = ["setuptools>=64", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "adaptive-agent"
+version = "0.1.0"
+description = "CLI 기반 AdaptiveAgent — 자연어 작업을 분석해 내장/생성 도구로 실행하는 오픈 코어 에이전트."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { text = "MIT" }
+authors = [{ name = "WowEunji", email = "ggss5927@gmail.com" }]
+keywords = ["agent", "llm", "cli", "tool-use", "skill-library"]
+classifiers = [
+    "Development Status :: 3 - Alpha",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: POSIX",
+    "Operating System :: MacOS :: MacOS X",
+    "Operating System :: POSIX :: Linux",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Libraries :: Python Modules",
+]
+dependencies = [
+    "ollama",
+    "openai>=1.40.0",
+    "google-genai>=1.0.0",
+    "python-dotenv",
+]
+
+[project.optional-dependencies]
+dev = ["mypy"]
+
+[project.urls]
+Homepage = "https://github.com/WOWEunji/AdaptiveAgent"
+Issues = "https://github.com/WOWEunji/AdaptiveAgent/issues"
+Source = "https://github.com/WOWEunji/AdaptiveAgent"
+
+[project.scripts]
+adaptive-agent = "adaptive_agent.cli:main"
+
+[tool.setuptools]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["adaptive_agent*"]
+exclude = ["tests*", "scripts*", "docs*"]
+
+[tool.setuptools.package-data]
+adaptive_agent = ["prompts/**/*.txt"]


### PR DESCRIPTION
## 요약

\`pip install -e .\` 가능한 패키지로 만들고 \`adaptive-agent\` 콘솔 진입점을 노출. 사용자 진입장벽 1순위 갭.

## 관련 이슈

미추적 항목이었음. 이 PR이 끝나면 후속 issue 등록 불필요.

## 변경 사항

- \`pyproject.toml\` 신설:
  - name \`adaptive-agent\` v0.1.0, MIT, Python>=3.10
  - dependencies는 requirements.txt 그대로 (ollama, openai>=1.40, google-genai>=1.0, python-dotenv)
  - \`[project.scripts]\` adaptive-agent = adaptive_agent.cli:main
  - prompts/\*\*/\*.txt 포함 보장
  - setuptools find_packages: tests/scripts/docs 제외
- README 설치 가이드를 \`pip install -e .\` 우선으로 갱신, 콘솔 명령 사용 예 추가

## 테스트

- [x] \`pip install -e .\` 성공
- [x] \`adaptive-agent --list-tools\` → 20개 builtin 정상 등록 확인
- [x] 125 tests 회귀 0

\`\`\`
$ pip install -e .
$ adaptive-agent --list-tools
- echo [atomic/builtin]: ...
- analyze_requirements [planning/builtin]: ...
... (20개)
\`\`\`

## Base

\`feature/agent-core-stabilization\` (PR #21).