### PR TITLE
feat(skills): introduce R5 skill_class enforcement (planning/functional/atomic)

### DIFF
--- a/adaptive_agent/skills/catalog.py
+++ b/adaptive_agent/skills/catalog.py
@@ -151,10 +151,17 @@ class SkillCatalog:
     def _normalize(self, metadata: dict[str, Any], *, use_existing: bool = True) -> dict[str, Any]:
         name = str(metadata.get("name") or "")
         existing = self._find_existing(name) if use_existing else {}
+        # 생성 도구 metadata는 R5 분류 (planning/functional/atomic) 중 하나여야
+        # 한다. 명시 안 되어 있으면 'functional'로 폴백 (대부분의 생성 도구는
+        # 도메인 효과를 만드는 functional skill).
+        raw_class = str(metadata.get("skill_class") or existing.get("skill_class") or "functional").lower()
+        if raw_class not in {"planning", "functional", "atomic"}:
+            raw_class = "functional"
         return {
             "name": name,
             "description": str(metadata.get("description") or existing.get("description") or ""),
             "category": str(metadata.get("category") or existing.get("category") or "generated"),
+            "skill_class": raw_class,
             "tags": _normalize_tags(metadata.get("tags") or existing.get("tags") or []),
             "file_path": str(metadata.get("file_path") or metadata.get("path") or existing.get("file_path") or ""),
             "file_hash": str(metadata.get("file_hash") or existing.get("file_hash") or ""),

--- a/adaptive_agent/tools/models.py
+++ b/adaptive_agent/tools/models.py
@@ -2,8 +2,27 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Callable
+
+
+# R5 (requirements_breakdown.md) 스킬 라이브러리 분류 — Tool은 이 셋 중
+# 정확히 하나에 속해야 한다. ``category``는 자유 설명 레이블(filesystem,
+# execution 등)이고, ``skill_class``는 planning context에 노출되는 정책
+# 분류다.
+#
+# - planning : 다음 행동을 결정하기 위한 메타 도구 (요구사항 분해, 후보
+#              검색, 다른 도구 추천 등). LLM이 plan 단계에서 자주 호출.
+# - functional: 특정 기능을 실제로 수행하는 도구 (파일 I/O, HTTP, 코드
+#              실행, 메모리 등). 보통 도메인 효과를 만든다.
+# - atomic   : 더 이상 쪼갤 수 없는 최소 단위 (echo, ask_human 같은
+#              순수 입출력 brick).
+SKILL_CLASS_PLANNING = "planning"
+SKILL_CLASS_FUNCTIONAL = "functional"
+SKILL_CLASS_ATOMIC = "atomic"
+SKILL_CLASSES: frozenset[str] = frozenset(
+    {SKILL_CLASS_PLANNING, SKILL_CLASS_FUNCTIONAL, SKILL_CLASS_ATOMIC}
+)
 
 
 @dataclass(frozen=True)
@@ -21,6 +40,14 @@ class Tool:
     parameters: dict[str, Any] | None = None
     returns: dict[str, Any] | None = None
     validation_status: str = "unverified"
+    skill_class: str = SKILL_CLASS_FUNCTIONAL
+
+    def __post_init__(self) -> None:
+        if self.skill_class not in SKILL_CLASSES:
+            raise ValueError(
+                f"Tool {self.name!r}: skill_class must be one of "
+                f"{sorted(SKILL_CLASSES)}, got {self.skill_class!r}"
+            )
 
 
 @dataclass(frozen=True)

--- a/adaptive_agent/tools/registry.py
+++ b/adaptive_agent/tools/registry.py
@@ -7,7 +7,13 @@ from pathlib import Path
 
 from adaptive_agent.skills import SkillCatalog
 from adaptive_agent.tools import builtins
-from adaptive_agent.tools.models import Tool, ToolExecutionResult
+from adaptive_agent.tools.models import (
+    SKILL_CLASS_ATOMIC,
+    SKILL_CLASS_FUNCTIONAL,
+    SKILL_CLASS_PLANNING,
+    Tool,
+    ToolExecutionResult,
+)
 from adaptive_agent.tools.sandbox import LocalSandboxBackend
 
 
@@ -91,6 +97,7 @@ def create_default_registry(
             description="입력 작업을 그대로 반환하는 상태 확인용 툴입니다.",
             handler=echo,
             category="atomic",
+            skill_class=SKILL_CLASS_ATOMIC,
             usage='python3 -m adaptive_agent --tool echo --arg task="echo hello"',
         )
     )
@@ -100,6 +107,7 @@ def create_default_registry(
             description="reference.md 방법론을 기반으로 프로젝트 요구사항을 분해합니다.",
             handler=analyze_requirements,
             category="planning",
+            skill_class=SKILL_CLASS_PLANNING,
             usage="python3 -m adaptive_agent --tool analyze_requirements",
         )
     )
@@ -109,6 +117,7 @@ def create_default_registry(
             description="등록된 내장 툴 목록을 출력합니다.",
             handler=list_tools,
             category="utility",
+            skill_class=SKILL_CLASS_PLANNING,
             usage="python3 -m adaptive_agent --list-tools",
         )
     )
@@ -118,6 +127,7 @@ def create_default_registry(
             description="작업공간 파일 목록을 안전하게 조회합니다.",
             handler=list_files,
             category="utility",
+            skill_class=SKILL_CLASS_FUNCTIONAL,
             usage="python3 -m adaptive_agent --tool list_files --arg path=adaptive_agent",
         )
     )
@@ -127,6 +137,7 @@ def create_default_registry(
             description="Python 코드를 별도 프로세스의 임시 작업공간에서 실행하고 결과/에러/기대값 판정을 반환합니다.",
             handler=lambda arguments: builtins.code_execute(arguments, sandbox=sandbox),
             category="execution",
+            skill_class=SKILL_CLASS_FUNCTIONAL,
             safety_level="high",
             usage='python3 -m adaptive_agent --json --tool code_execute --arg code="print(1)" --arg lang=python',
         )
@@ -137,6 +148,7 @@ def create_default_registry(
             description="셸 명령을 별도 프로세스의 임시 작업공간에서 실행하고 결과/에러/기대값 판정을 반환합니다.",
             handler=lambda arguments: builtins.shell_run(arguments, sandbox=sandbox),
             category="execution",
+            skill_class=SKILL_CLASS_FUNCTIONAL,
             safety_level="high",
             usage='python3 -m adaptive_agent --json --tool shell_run --arg code="echo ok"',
         )
@@ -147,6 +159,7 @@ def create_default_registry(
             description="워크스페이스 내부 UTF-8 텍스트 파일을 읽습니다.",
             handler=lambda arguments: builtins.file_read(arguments, workspace=workspace),
             category="filesystem",
+            skill_class=SKILL_CLASS_FUNCTIONAL,
             safety_level="medium",
             usage="python3 -m adaptive_agent --json --tool file_read --arg path=README.md",
         )
@@ -157,6 +170,7 @@ def create_default_registry(
             description="워크스페이스 내부 파일에 UTF-8 텍스트를 씁니다.",
             handler=lambda arguments: builtins.file_write(arguments, workspace=workspace),
             category="filesystem",
+            skill_class=SKILL_CLASS_FUNCTIONAL,
             safety_level="high",
             usage='python3 -m adaptive_agent --json --tool file_write --arg path=notes.txt --arg content="hello"',
         )
@@ -177,6 +191,7 @@ def create_default_registry(
             description="워크스페이스 내부 UTF-8 파일에 단일 텍스트 치환 패치를 적용하거나 diff를 미리 봅니다.",
             handler=lambda arguments: builtins.file_patch(arguments, workspace=workspace),
             category="filesystem",
+            skill_class=SKILL_CLASS_FUNCTIONAL,
             safety_level="high",
             usage='python3 -m adaptive_agent --json --tool file_patch --arg path=notes.txt --arg old_text=old --arg new_text=new --arg dry_run=true',
         )
@@ -187,6 +202,7 @@ def create_default_registry(
             description="사용자에게 질문 또는 선택지를 요청하는 pending_human_input 결과를 반환합니다.",
             handler=builtins.ask_human,
             category="human_in_the_loop",
+            skill_class=SKILL_CLASS_ATOMIC,
             safety_level="low",
             usage='python3 -m adaptive_agent --json --tool ask_human --arg questions="어떤 옵션을 선택할까요?"',
         )
@@ -197,6 +213,7 @@ def create_default_registry(
             description="실행 전 계획과 위험도를 제시하고 사용자 승인이 필요함을 반환합니다.",
             handler=builtins.propose_actions,
             category="human_in_the_loop",
+            skill_class=SKILL_CLASS_ATOMIC,
             safety_level="low",
             usage='python3 -m adaptive_agent --json --tool propose_actions --arg plan="파일을 수정합니다" --arg risk_level=medium',
         )
@@ -207,6 +224,7 @@ def create_default_registry(
             description="프로젝트 테스트 명령을 워크스페이스 복사본에서 실행하고 결과/기대값 판정을 반환합니다.",
             handler=lambda arguments: builtins.test_run(arguments, sandbox=sandbox),
             category="execution",
+            skill_class=SKILL_CLASS_FUNCTIONAL,
             safety_level="high",
             usage='python3 -m adaptive_agent --json --tool test_run --arg command="python3 -m unittest discover"',
         )
@@ -217,6 +235,7 @@ def create_default_registry(
             description="새 Python 도구 코드를 툴 라이브러리에 저장합니다.",
             handler=lambda arguments: builtins.tool_create(arguments, tool_library=tool_library),
             category="tool_library",
+            skill_class=SKILL_CLASS_FUNCTIONAL,
             safety_level="high",
             usage='python3 -m adaptive_agent --json --tool tool_create --arg name=my_tool --arg description="..." --arg code="def run(args): return args"',
         )
@@ -241,6 +260,7 @@ def create_default_registry(
                 tool_library=tool_library,
             ),
             category="tool_library",
+            skill_class=SKILL_CLASS_PLANNING,
             safety_level="low",
             usage="python3 -m adaptive_agent --json --tool tool_search --arg query=file",
         )
@@ -255,6 +275,7 @@ def create_default_registry(
                 sandbox=sandbox,
             ),
             category="tool_library",
+            skill_class=SKILL_CLASS_FUNCTIONAL,
             safety_level="high",
             usage="python3 -m adaptive_agent --json --tool tool_validate --arg name=my_tool",
         )
@@ -265,6 +286,7 @@ def create_default_registry(
             description="사용자 승인 후 검증된 생성 도구를 manifest 스킬 카탈로그에 등록합니다.",
             handler=lambda arguments: builtins.tool_approve(arguments, tool_library=tool_library),
             category="tool_library",
+            skill_class=SKILL_CLASS_FUNCTIONAL,
             safety_level="high",
             usage="python3 -m adaptive_agent --json --tool tool_approve --arg name=my_tool",
         )
@@ -275,6 +297,7 @@ def create_default_registry(
             description="에이전트 로컬 메모리 값을 읽습니다.",
             handler=lambda arguments: builtins.memory_read(arguments, memory_dir=memory_dir),
             category="memory",
+            skill_class=SKILL_CLASS_FUNCTIONAL,
             safety_level="medium",
             usage="python3 -m adaptive_agent --json --tool memory_read --arg key=preference",
         )
@@ -285,6 +308,7 @@ def create_default_registry(
             description="사용자 승인 후 유지할 에이전트 로컬 메모리 값을 저장합니다.",
             handler=lambda arguments: builtins.memory_write(arguments, memory_dir=memory_dir),
             category="memory",
+            skill_class=SKILL_CLASS_FUNCTIONAL,
             safety_level="high",
             usage='python3 -m adaptive_agent --json --tool memory_write --arg key=preference --arg value="한국어 응답"',
         )
@@ -295,6 +319,7 @@ def create_default_registry(
             description="현재 목록 외에 추가로 유용한 내장 도구 후보와 이유를 반환합니다.",
             handler=builtins.suggested_builtin_tools,
             category="planning",
+            skill_class=SKILL_CLASS_PLANNING,
             safety_level="low",
             usage="python3 -m adaptive_agent --tool suggest_builtin_tools",
         )
@@ -336,6 +361,9 @@ def load_generated_tools(
         if actual_hash != expected_hash:
             load_results.append({"name": name, "loaded": False, "reason": "generated_tool_file_hash_mismatch"})
             continue
+        raw_skill_class = str(metadata.get("skill_class") or "functional").lower()
+        if raw_skill_class not in {"planning", "functional", "atomic"}:
+            raw_skill_class = "functional"
         registry.register(
             Tool(
                 name=name,
@@ -347,6 +375,7 @@ def load_generated_tools(
                     sandbox=sandbox,
                 ),
                 category=str(metadata.get("category") or "generated"),
+                skill_class=raw_skill_class,
                 safety_level=str(metadata.get("safety_level") or "high"),
                 usage=f"python3 -m adaptive_agent --json --tool {name}",
                 source="generated",

--- a/tests/test_skills_classification.py
+++ b/tests/test_skills_classification.py
@@ -1,0 +1,136 @@
+"""Skills 분류 정책(planning/functional/atomic) 테스트.
+
+R5 (requirements_breakdown.md) — 모든 도구는 세 분류 중 정확히 하나에
+속해야 한다. ``Tool.skill_class``는 도구 등록 시점에 강제되고, generated
+도구는 manifest의 ``skill_class`` 필드(없으면 'functional' 폴백)를 따른다.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from adaptive_agent.skills import SkillCatalog
+from adaptive_agent.tools.models import (
+    SKILL_CLASS_ATOMIC,
+    SKILL_CLASS_FUNCTIONAL,
+    SKILL_CLASS_PLANNING,
+    SKILL_CLASSES,
+    Tool,
+    ToolExecutionResult,
+)
+from adaptive_agent.tools.registry import create_default_registry
+
+
+def _noop(_args):
+    return ToolExecutionResult(success=True, output=None)
+
+
+class SkillClassEnumTest(unittest.TestCase):
+    def test_three_classes_are_defined(self) -> None:
+        self.assertEqual(SKILL_CLASSES, frozenset({"planning", "functional", "atomic"}))
+        self.assertEqual(SKILL_CLASS_PLANNING, "planning")
+        self.assertEqual(SKILL_CLASS_FUNCTIONAL, "functional")
+        self.assertEqual(SKILL_CLASS_ATOMIC, "atomic")
+
+
+class ToolValidationTest(unittest.TestCase):
+    def test_valid_skill_class_accepted(self) -> None:
+        for cls in SKILL_CLASSES:
+            with self.subTest(skill_class=cls):
+                tool = Tool(name=f"t_{cls}", description="d", handler=_noop, skill_class=cls)
+                self.assertEqual(tool.skill_class, cls)
+
+    def test_invalid_skill_class_rejected(self) -> None:
+        for bad in ("invalid", "PLANNING", "operational", ""):
+            with self.subTest(skill_class=bad):
+                with self.assertRaises(ValueError) as ctx:
+                    Tool(name="bad", description="d", handler=_noop, skill_class=bad)
+                self.assertIn("skill_class", str(ctx.exception))
+
+    def test_default_skill_class_is_functional(self) -> None:
+        tool = Tool(name="defaulted", description="d", handler=_noop)
+        self.assertEqual(tool.skill_class, "functional")
+
+
+class DefaultRegistrySkillClassesTest(unittest.TestCase):
+    """등록된 모든 builtin이 planning/functional/atomic 중 하나에 속함."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+        self.registry = create_default_registry(self.workspace)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_every_builtin_has_valid_skill_class(self) -> None:
+        for tool in self.registry.list():
+            with self.subTest(tool=tool.name):
+                self.assertIn(tool.skill_class, SKILL_CLASSES)
+
+    def test_known_planning_tools(self) -> None:
+        # 명시적 회귀: 정확히 어떤 도구가 planning에 들어가는지 잠금
+        planning = {tool.name for tool in self.registry.list() if tool.skill_class == "planning"}
+        self.assertIn("analyze_requirements", planning)
+        self.assertIn("list_tools", planning)
+        self.assertIn("tool_search", planning)
+        self.assertIn("suggest_builtin_tools", planning)
+
+    def test_known_atomic_tools(self) -> None:
+        atomic = {tool.name for tool in self.registry.list() if tool.skill_class == "atomic"}
+        self.assertIn("echo", atomic)
+        self.assertIn("ask_human", atomic)
+        self.assertIn("propose_actions", atomic)
+
+    def test_known_functional_tools(self) -> None:
+        functional = {tool.name for tool in self.registry.list() if tool.skill_class == "functional"}
+        for expected in {
+            "code_execute",
+            "shell_run",
+            "file_read",
+            "file_write",
+            "file_list",
+            "file_patch",
+            "test_run",
+            "tool_create",
+            "tool_validate",
+            "tool_approve",
+            "memory_read",
+            "memory_write",
+        }:
+            self.assertIn(expected, functional, f"{expected}는 functional이어야 함")
+
+
+class GeneratedToolSkillClassTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+        self.tool_library = self.workspace / ".adaptive_agent" / "tools"
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_manifest_normalize_defaults_skill_class_to_functional(self) -> None:
+        catalog = SkillCatalog(self.tool_library)
+        normalized = catalog._normalize({"name": "anon_tool", "description": "x"}, use_existing=False)
+        self.assertEqual(normalized["skill_class"], "functional")
+
+    def test_manifest_normalize_preserves_explicit_skill_class(self) -> None:
+        catalog = SkillCatalog(self.tool_library)
+        for cls in ("planning", "functional", "atomic"):
+            with self.subTest(skill_class=cls):
+                normalized = catalog._normalize(
+                    {"name": f"t_{cls}", "skill_class": cls}, use_existing=False
+                )
+                self.assertEqual(normalized["skill_class"], cls)
+
+    def test_manifest_normalize_falls_back_for_invalid_class(self) -> None:
+        catalog = SkillCatalog(self.tool_library)
+        normalized = catalog._normalize({"name": "weird", "skill_class": "invalid"}, use_existing=False)
+        self.assertEqual(normalized["skill_class"], "functional")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

requirements_breakdown.md R5의 "스킬을 planning/functional/atomic으로 분류한다"를 코드 레벨에서 강제. \`Tool\`과 manifest entry 모두 정확히 한 분류에 속하도록 검증.

## 관련 이슈

미추적 항목이었음 (블루프린트 R5).

## 변경 사항

- \`adaptive_agent/tools/models.py\`: \`SKILL_CLASS_*\` 상수 + \`SKILL_CLASSES\` frozenset, \`Tool.skill_class\` 필드(default \`functional\`), \`__post_init__\` 검증
- \`adaptive_agent/tools/registry.py\`: 모든 builtin에 적절한 \`skill_class\` 부여
- \`adaptive_agent/skills/catalog.py::_normalize\`: manifest에 \`skill_class\` 저장 + 폴백
- \`adaptive_agent/tools/registry.py::load_generated_tools\`: metadata의 skill_class를 Tool에 전달

## 분류 (잠금)

- **planning**: analyze_requirements / list_tools / tool_search / suggest_builtin_tools
- **atomic**: echo / ask_human / propose_actions
- **functional**: code_execute / shell_run / file_read/write/list/patch / test_run / tool_create/validate/approve / memory_read/write / list_files / artifact_store / web_fetch (PR #26)

## 호환성

- 기존 builtin 모두 명시적 \`skill_class\` 받음 → 회귀 0
- 기존 manifest 항목은 \`_normalize\` 폴백으로 자동 분류 (모두 \`functional\`)

## 테스트 (11 신규)

- [x] 세 enum 정의 검증
- [x] 유효/무효 \`skill_class\` 수용/거부
- [x] 기본값 = functional
- [x] 모든 builtin에 분류 부여됨
- [x] 분류별 화이트리스트 잠금
- [x] generated tool 폴백 (누락/명시/잘못된 값)

\`\`\`
$ python -m unittest discover -s tests
Ran 136 tests in 0.936s — OK
\`\`\`

## Base

\`feature/agent-core-stabilization\` (PR #21).