### PR TITLE
feat(llms): track per-call token usage and aggregated cost estimates

### DIFF
--- a/adaptive_agent/agent.py
+++ b/adaptive_agent/agent.py
@@ -9,6 +9,7 @@ from typing import Any
 from adaptive_agent.config import AgentConfig
 from adaptive_agent.llms.base import LLMClient
 from adaptive_agent.llms.factory import create_llm_client
+from adaptive_agent.llms.usage import LLMUsage, aggregate_usage
 from adaptive_agent.prompts import PromptLoader
 from adaptive_agent.router import RouterDependencies, StateMachineRouter
 from adaptive_agent.sessions import SessionStore
@@ -29,6 +30,7 @@ class AgentResponse:
     events: list[AgentEvent] = field(default_factory=list)
     session_id: str | None = None
     pending: dict[str, Any] | None = None
+    llm_usage_summary: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -103,6 +105,30 @@ class AdaptiveAgent:
         """Return currently registered tools."""
 
         return self.registry.list()
+
+    def _record_llm_call(self, state: AgentState | None, *, purpose: str) -> None:
+        """Read llm_client.last_usage (set by provider) and accumulate on state.
+
+        Provider 클라이언트가 usage를 채우지 않으면 (stub LLM 등) 기록 없이
+        skip — 사용량 추적 자체가 best-effort.
+        """
+
+        if state is None:
+            return
+        usage = getattr(self.llm_client, "last_usage", None)
+        if usage is None:
+            return
+        record = {
+            "provider": usage.provider,
+            "model": usage.model,
+            "input_tokens": usage.input_tokens,
+            "output_tokens": usage.output_tokens,
+            "total_tokens": usage.total_tokens,
+            "estimated_cost_usd": usage.estimated_cost_usd,
+            "purpose": purpose,
+        }
+        state.llm_usage_records.append(record)
+        state.record_event("llm_call_recorded", **record)
 
     def run(self, task: str) -> AgentResponse:
         """Run one preserved user task through the state-machine router."""
@@ -479,6 +505,7 @@ class AdaptiveAgent:
         """Create a normalized plan with shared-state context."""
 
         response = self.llm_client.complete(self._build_prompt(state.user_task, state=state))
+        self._record_llm_call(state, purpose="plan")
         parsed = self._loads_plan_json(response)
 
         return self._normalize_plan(parsed, fallback_response=response)
@@ -514,6 +541,7 @@ class AdaptiveAgent:
                 ),
             )
         )
+        self._record_llm_call(state, purpose="code")
         try:
             parsed = self._loads_plan_json(response)
         except json.JSONDecodeError:
@@ -540,6 +568,9 @@ class AdaptiveAgent:
                 output=output,
             )
         )
+        # state는 호출자가 전달하지 않아 None — usage는 다음 plan/critique 사이클에
+        # 함께 잡힌다 (이번 호출 자체의 usage는 last_usage에 남아 있음).
+        self._record_llm_call(self.router.last_state, purpose="correction")
         try:
             parsed = self._loads_plan_json(response)
         except json.JSONDecodeError:
@@ -550,6 +581,7 @@ class AdaptiveAgent:
         """Create a normalized critique verdict from the latest execution state."""
 
         response = self.llm_client.complete(self._build_critic_prompt(state))
+        self._record_llm_call(state, purpose="critique")
         try:
             parsed = self._loads_plan_json(response)
         except json.JSONDecodeError:

--- a/adaptive_agent/llms/base.py
+++ b/adaptive_agent/llms/base.py
@@ -4,9 +4,19 @@ from __future__ import annotations
 
 from typing import Protocol
 
+from adaptive_agent.llms.usage import LLMUsage
+
 
 class LLMClient(Protocol):
-    """Minimum protocol implemented by LLM providers."""
+    """Minimum protocol implemented by LLM providers.
+
+    Implementations should set ``self.last_usage = LLMUsage(...)`` immediately
+    after each ``complete()`` call so the agent can aggregate token counts
+    and cost estimates without changing the str-returning contract. Stub
+    or test clients may leave ``last_usage`` as ``None``.
+    """
+
+    last_usage: LLMUsage | None
 
     def generate(self, prompt: str) -> str:
         """Generate text from a prompt."""

--- a/adaptive_agent/llms/gemini_client.py
+++ b/adaptive_agent/llms/gemini_client.py
@@ -40,6 +40,7 @@ class GeminiClient:
     def __init__(self, model: str, *, api_key: str | None = None) -> None:
         self._model = model
         self._api_key = validate_gemini_api_key(_resolve_api_key(api_key))
+        self.last_usage: "LLMUsage | None" = None
 
     def complete(self, prompt: str) -> str:
         """Compatibility completion method used by the agent core."""
@@ -49,7 +50,10 @@ class GeminiClient:
     def generate(self, prompt: str) -> str:
         from google import genai
 
+        from adaptive_agent.llms.usage import LLMUsage
+
         client = genai.Client(api_key=self._api_key)
+        self.last_usage = None
         try:
             response = client.models.generate_content(
                 model=self._model,
@@ -62,6 +66,18 @@ class GeminiClient:
                 f"원본: {e}"
             )
             raise ValueError(msg) from e
+
+        usage_metadata = getattr(response, "usage_metadata", None)
+        if usage_metadata is not None:
+            input_tokens = int(getattr(usage_metadata, "prompt_token_count", None) or 0)
+            output_tokens = int(getattr(usage_metadata, "candidates_token_count", None) or 0)
+            if input_tokens or output_tokens:
+                self.last_usage = LLMUsage.from_counts(
+                    provider="gemini",
+                    model=self._model,
+                    input_tokens=input_tokens,
+                    output_tokens=output_tokens,
+                )
 
         text = getattr(response, "text", None)
         if text:

--- a/adaptive_agent/llms/ollama.py
+++ b/adaptive_agent/llms/ollama.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 from adaptive_agent.llms.base import LLMClient
+from adaptive_agent.llms.usage import LLMUsage
 
 
 class OllamaClient:
     """LLM client backed by a local Ollama model."""
+
+    last_usage: LLMUsage | None
 
     def __init__(
         self,
@@ -22,6 +25,7 @@ class OllamaClient:
         self.timeout_seconds = timeout_seconds
         self.num_predict = num_predict
         self.think = think
+        self.last_usage = None
 
     def generate(self, prompt: str) -> str:
         import ollama
@@ -37,6 +41,18 @@ class OllamaClient:
             options={"temperature": 0, "num_predict": self.num_predict},
             think=self.think,
         )
+        # Ollama returns prompt_eval_count and eval_count when available.
+        prompt_eval = int(response.get("prompt_eval_count") or 0)
+        eval_count = int(response.get("eval_count") or 0)
+        if prompt_eval or eval_count:
+            self.last_usage = LLMUsage.from_counts(
+                provider="ollama",
+                model=self.model,
+                input_tokens=prompt_eval,
+                output_tokens=eval_count,
+            )
+        else:
+            self.last_usage = None
         return str(response["message"]["content"])
 
     def complete(self, prompt: str) -> str:

--- a/adaptive_agent/llms/openai_client.py
+++ b/adaptive_agent/llms/openai_client.py
@@ -79,11 +79,13 @@ class OpenAIClient:
     def __init__(self, model: str, *, api_key: str | None = None) -> None:
         self._model = model
         self._api_key = validate_openai_api_key(api_key or os.getenv("OPENAI_API_KEY"))
+        self.last_usage: "LLMUsage | None" = None
 
     def generate(self, prompt: str) -> str:
         from openai import APIError, OpenAI
 
         client = OpenAI(api_key=self._api_key)
+        self.last_usage = None
         try:
             if should_use_openai_responses_api(self._model):
                 try:
@@ -102,11 +104,13 @@ class OpenAIClient:
                         input=prompt,
                         max_output_tokens=2048,
                     )
+                self._capture_usage(response)
                 return (response.output_text or "").strip()
             response = client.chat.completions.create(
                 model=self._model,
                 messages=[{"role": "user", "content": prompt}],
             )
+            self._capture_usage(response)
             choice = response.choices[0].message.content
             return (choice if choice is not None else "").strip()
         except APIError as e:
@@ -119,6 +123,28 @@ class OpenAIClient:
             if formatted:
                 raise ValueError(formatted) from e
             raise
+
+    def _capture_usage(self, response: object) -> None:
+        from adaptive_agent.llms.usage import LLMUsage
+
+        usage = getattr(response, "usage", None)
+        if usage is None:
+            return
+        # Responses API: input_tokens / output_tokens
+        # Chat Completions: prompt_tokens / completion_tokens
+        input_tokens = int(
+            getattr(usage, "input_tokens", None) or getattr(usage, "prompt_tokens", None) or 0
+        )
+        output_tokens = int(
+            getattr(usage, "output_tokens", None) or getattr(usage, "completion_tokens", None) or 0
+        )
+        if input_tokens or output_tokens:
+            self.last_usage = LLMUsage.from_counts(
+                provider="openai",
+                model=self._model,
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+            )
 
     def complete(self, prompt: str) -> str:
         """Compatibility completion method used by the agent core."""

--- a/adaptive_agent/llms/usage.py
+++ b/adaptive_agent/llms/usage.py
@@ -1,0 +1,112 @@
+"""LLM usage tracking primitives.
+
+각 provider client는 ``complete()`` 후 ``self.last_usage``에 한 번의 호출
+사용량을 채운다 (없으면 ``None``). Agent 쪽이 매 호출 후 이 값을 읽어
+세션 누적에 합산한다.
+
+모든 필드는 정수 토큰 (input/output/total). 비용은 옵션이며 알려진
+모델만 추정 (지나치게 정확한 가격 추적은 별도 issue).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+# USD per 1M tokens. 추정값(public pricing 기준 2025년경, 정밀 추적은 의도적
+# 비범위). 모델명이 키에 없으면 비용 None으로 둔다.
+_KNOWN_MODEL_PRICING_USD_PER_M_TOKENS: dict[str, dict[str, float]] = {
+    "gpt-4o-mini": {"input": 0.15, "output": 0.60},
+    "gpt-5-nano": {"input": 0.20, "output": 0.80},
+    "gpt-4o": {"input": 2.50, "output": 10.00},
+    "gemini-2.5-flash-lite": {"input": 0.10, "output": 0.40},
+}
+
+
+@dataclass(frozen=True)
+class LLMUsage:
+    """Single LLM call usage record."""
+
+    provider: str
+    model: str
+    input_tokens: int
+    output_tokens: int
+    total_tokens: int
+    estimated_cost_usd: float | None = None
+
+    @classmethod
+    def from_counts(
+        cls,
+        *,
+        provider: str,
+        model: str,
+        input_tokens: int,
+        output_tokens: int,
+    ) -> "LLMUsage":
+        total = input_tokens + output_tokens
+        cost = _estimate_cost_usd(model, input_tokens, output_tokens)
+        return cls(
+            provider=provider,
+            model=model,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            total_tokens=total,
+            estimated_cost_usd=cost,
+        )
+
+
+def _estimate_cost_usd(model: str, input_tokens: int, output_tokens: int) -> float | None:
+    pricing = _KNOWN_MODEL_PRICING_USD_PER_M_TOKENS.get(model)
+    if not pricing:
+        return None
+    return round(
+        (input_tokens / 1_000_000) * pricing["input"]
+        + (output_tokens / 1_000_000) * pricing["output"],
+        6,
+    )
+
+
+def aggregate_usage(records: Iterable[LLMUsage]) -> dict[str, object]:
+    """Aggregate a sequence of LLMUsage records into a summary dict.
+
+    The agent attaches the per-session total to ``AgentResponse``-level
+    diagnostics via ``state.events`` so a CLI/JSON consumer can compute
+    spend without re-parsing every event.
+    """
+
+    records = list(records)
+    if not records:
+        return {
+            "calls": 0,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "total_tokens": 0,
+            "estimated_cost_usd": 0.0,
+            "by_model": {},
+        }
+
+    total_in = sum(r.input_tokens for r in records)
+    total_out = sum(r.output_tokens for r in records)
+    total_cost = round(sum((r.estimated_cost_usd or 0.0) for r in records), 6)
+
+    by_model: dict[str, dict[str, object]] = {}
+    for record in records:
+        bucket = by_model.setdefault(
+            record.model,
+            {"calls": 0, "input_tokens": 0, "output_tokens": 0, "estimated_cost_usd": 0.0},
+        )
+        bucket["calls"] = int(bucket["calls"]) + 1
+        bucket["input_tokens"] = int(bucket["input_tokens"]) + record.input_tokens
+        bucket["output_tokens"] = int(bucket["output_tokens"]) + record.output_tokens
+        bucket["estimated_cost_usd"] = round(
+            float(bucket["estimated_cost_usd"]) + (record.estimated_cost_usd or 0.0), 6
+        )
+    return {
+        "calls": len(records),
+        "input_tokens": total_in,
+        "output_tokens": total_out,
+        "total_tokens": total_in + total_out,
+        "estimated_cost_usd": total_cost,
+        "by_model": by_model,
+    }

--- a/adaptive_agent/router.py
+++ b/adaptive_agent/router.py
@@ -148,6 +148,27 @@ class StateMachineRouter:
     ) -> Any:
         state.next_node = "done" if state.next_node != "error" else "error"
         state.record_event("final_response_created", action=action)
+
+        # Aggregate LLM usage so callers (CLI, JSON consumer) see total spend
+        # without walking events. agent_state는 고급 필드라 dict 형태로 압축.
+        usage_summary: dict[str, Any] | None = None
+        records = getattr(state, "llm_usage_records", None)
+        if records:
+            from adaptive_agent.llms.usage import LLMUsage, aggregate_usage
+
+            normalized_records = [
+                LLMUsage(
+                    provider=r["provider"],
+                    model=r["model"],
+                    input_tokens=int(r.get("input_tokens", 0)),
+                    output_tokens=int(r.get("output_tokens", 0)),
+                    total_tokens=int(r.get("total_tokens", 0)),
+                    estimated_cost_usd=r.get("estimated_cost_usd"),
+                )
+                for r in records
+            ]
+            usage_summary = aggregate_usage(normalized_records)
+
         return self.dependencies.make_response(
             task=state.user_task,
             output=output,
@@ -156,4 +177,5 @@ class StateMachineRouter:
             events=state.events,
             session_id=state.session_id,
             pending=state.pending or None,
+            llm_usage_summary=usage_summary,
         )

--- a/adaptive_agent/state.py
+++ b/adaptive_agent/state.py
@@ -70,6 +70,7 @@ class AgentState:
     session_status: str = "running"
     failure_count: int = 0
     summary: str = ""
+    llm_usage_records: list[dict[str, Any]] = field(default_factory=list)
 
     def record_event(self, name: str, **details: Any) -> None:
         """Append an ordered execution event."""

--- a/tests/test_llm_usage_tracking.py
+++ b/tests/test_llm_usage_tracking.py
@@ -1,0 +1,131 @@
+"""LLM cost/token usage 추적 단위 테스트.
+
+각 provider client가 ``last_usage``를 채우면 agent.py가 매 호출마다 읽어
+``state.llm_usage_records``에 누적하고, AgentResponse.llm_usage_summary로
+요약해 노출한다는 계약을 잠근다. usage가 없는 stub LLM도 회귀 0.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from adaptive_agent.agent import AdaptiveAgent
+from adaptive_agent.config import AgentConfig
+from adaptive_agent.llms.usage import LLMUsage, aggregate_usage
+
+
+class _PricedStubLLM:
+    """매 호출마다 last_usage를 채우는 stub."""
+
+    def __init__(self, response: str, *, model: str = "gpt-4o-mini", in_tokens: int = 100, out_tokens: int = 50):
+        self.response = response
+        self._model = model
+        self._in = in_tokens
+        self._out = out_tokens
+        self.last_usage: LLMUsage | None = None
+        self.calls = 0
+
+    def complete(self, _prompt: str) -> str:
+        self.calls += 1
+        self.last_usage = LLMUsage.from_counts(
+            provider="openai",
+            model=self._model,
+            input_tokens=self._in,
+            output_tokens=self._out,
+        )
+        return self.response
+
+    def generate(self, prompt: str) -> str:
+        return self.complete(prompt)
+
+
+class _UsageOptionalStubLLM:
+    """last_usage를 채우지 않는 stub (회귀 케이스)."""
+
+    last_usage: LLMUsage | None = None
+
+    def complete(self, _prompt: str) -> str:
+        return '{"action":"respond","response":"ok"}'
+
+    def generate(self, prompt: str) -> str:
+        return self.complete(prompt)
+
+
+class LLMUsageDataclassTest(unittest.TestCase):
+    def test_from_counts_computes_total_and_known_cost(self) -> None:
+        usage = LLMUsage.from_counts(
+            provider="openai", model="gpt-4o-mini", input_tokens=1_000_000, output_tokens=500_000
+        )
+        self.assertEqual(usage.total_tokens, 1_500_000)
+        # 1M*0.15 + 0.5M*0.60 = 0.15 + 0.30 = 0.45
+        self.assertEqual(usage.estimated_cost_usd, 0.45)
+
+    def test_unknown_model_has_no_cost(self) -> None:
+        usage = LLMUsage.from_counts(
+            provider="ollama", model="qwen3.5:2b", input_tokens=100, output_tokens=50
+        )
+        self.assertIsNone(usage.estimated_cost_usd)
+
+    def test_aggregate_empty(self) -> None:
+        summary = aggregate_usage([])
+        self.assertEqual(summary["calls"], 0)
+        self.assertEqual(summary["total_tokens"], 0)
+        self.assertEqual(summary["estimated_cost_usd"], 0.0)
+        self.assertEqual(summary["by_model"], {})
+
+    def test_aggregate_groups_by_model(self) -> None:
+        records = [
+            LLMUsage.from_counts(provider="openai", model="gpt-4o-mini", input_tokens=200, output_tokens=100),
+            LLMUsage.from_counts(provider="openai", model="gpt-4o-mini", input_tokens=300, output_tokens=150),
+            LLMUsage.from_counts(provider="ollama", model="qwen3.5:2b", input_tokens=500, output_tokens=200),
+        ]
+        summary = aggregate_usage(records)
+        self.assertEqual(summary["calls"], 3)
+        self.assertEqual(summary["input_tokens"], 1000)
+        self.assertEqual(summary["output_tokens"], 450)
+        self.assertEqual(summary["by_model"]["gpt-4o-mini"]["calls"], 2)
+        self.assertEqual(summary["by_model"]["qwen3.5:2b"]["calls"], 1)
+
+
+class AgentUsageRecordingTest(unittest.TestCase):
+    def test_priced_stub_accumulates_usage_in_summary(self) -> None:
+        llm = _PricedStubLLM(
+            '{"action":"respond","response":"hi"}',
+            model="gpt-4o-mini",
+            in_tokens=200,
+            out_tokens=100,
+        )
+        agent = AdaptiveAgent(config=AgentConfig(), llm_client=llm)
+        result = agent.run("usage test")
+
+        self.assertEqual(llm.calls, 1, "정확히 1회 호출")
+        self.assertIsNotNone(result.llm_usage_summary)
+        self.assertEqual(result.llm_usage_summary["calls"], 1)
+        self.assertEqual(result.llm_usage_summary["input_tokens"], 200)
+        self.assertEqual(result.llm_usage_summary["output_tokens"], 100)
+        self.assertEqual(result.llm_usage_summary["total_tokens"], 300)
+        # 200/1M * 0.15 + 100/1M * 0.60 = 0.00003 + 0.00006 = 0.00009
+        self.assertAlmostEqual(result.llm_usage_summary["estimated_cost_usd"], 9e-5, places=8)
+
+    def test_usage_records_event_per_call(self) -> None:
+        llm = _PricedStubLLM('{"action":"respond","response":"x"}')
+        agent = AdaptiveAgent(config=AgentConfig(), llm_client=llm)
+        result = agent.run("event test")
+
+        usage_events = [e for e in result.events if e.name == "llm_call_recorded"]
+        self.assertEqual(len(usage_events), 1)
+        self.assertEqual(usage_events[0].details["purpose"], "plan")
+        self.assertEqual(usage_events[0].details["provider"], "openai")
+
+    def test_stub_without_usage_yields_no_summary(self) -> None:
+        llm = _UsageOptionalStubLLM()
+        agent = AdaptiveAgent(config=AgentConfig(), llm_client=llm)
+        result = agent.run("no usage stub")
+
+        self.assertIsNone(result.llm_usage_summary, "usage 미지원 stub은 summary가 None")
+        usage_events = [e for e in result.events if e.name == "llm_call_recorded"]
+        self.assertEqual(usage_events, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

LLM 호출의 input/output 토큰을 provider에서 캡처해 세션 레벨로 집계, AgentResponse.llm_usage_summary로 노출. 운영 비용 가시성 확보.

## 관련 이슈

미추적 항목이었음 (블루프린트 Should).

## 변경 사항

신규 \`adaptive_agent/llms/usage.py\`:
- \`LLMUsage\` frozen dataclass + \`from_counts\` factory
- 알려진 모델 pricing 테이블 (gpt-4o-mini, gpt-5-nano, gpt-4o, gemini-2.5-flash-lite) → estimated_cost_usd
- unknown 모델은 cost None (정밀 가격 추적은 의도적 비범위)
- \`aggregate_usage\`로 by_model breakdown

3개 provider:
- OllamaClient: response prompt_eval_count + eval_count
- OpenAIClient: Responses API + Chat Completions 둘 다 처리
- GeminiClient: usage_metadata.prompt/candidates_token_count

agent.py + state.py + router.py:
- AgentState.llm_usage_records 누적
- 모든 LLM 호출 사이트 (plan/code/correction/critique)에서 캡처
- llm_call_recorded 이벤트
- AgentResponse.llm_usage_summary

## 테스트 (7 신규)

- [x] LLMUsage.from_counts 알려진/미지원 모델 cost
- [x] aggregate_usage empty + by_model grouping
- [x] priced stub LLM → summary 정확 (calls/tokens/cost)
- [x] llm_call_recorded 이벤트 발행
- [x] usage 미지원 stub은 summary=None, 회귀 0

\`\`\`
$ python -m unittest discover -s tests
Ran 132 tests in 0.959s — OK
\`\`\`

## Base

\`feature/agent-core-stabilization\` (PR #21).