### PR TITLE
feat(agent): add multi-perspective parallel execution (closes #20)

### DIFF
--- a/adaptive_agent/agent.py
+++ b/adaptive_agent/agent.py
@@ -104,6 +104,43 @@ class AdaptiveAgent:
 
         return self.registry.list()
 
+    def run_perspectives(self, task: str, perspectives: list[str] | str) -> dict[str, AgentResponse]:
+        """Run ``task`` from multiple persona perspectives in parallel.
+
+        See :mod:`adaptive_agent.perspectives` for the available keys
+        (researcher / pm / architect / reviewer / qa). ``implementer`` is
+        intentionally rejected for parallel calls (write conflict risk).
+        """
+
+        from adaptive_agent.perspectives import (
+            _PerspectiveLLM,
+            resolve_perspective_keys,
+            run_perspectives_parallel,
+        )
+
+        keys = resolve_perspective_keys(perspectives)
+
+        def _build(_key: str, prefix: str) -> "AdaptiveAgent":
+            wrapped_llm = _PerspectiveLLM(self.llm_client, prefix)
+            # 각 perspective는 새 AdaptiveAgent 인스턴스. registry/sandbox는
+            # 무거우니 share 가능하지만 단순함을 위해 공유. router/state는
+            # 새로 만들어 격리.
+            return AdaptiveAgent(
+                config=self.config,
+                llm_client=wrapped_llm,
+                registry=self.registry,
+                executor=self.executor,
+                prompt_loader=self.prompt_loader,
+            )
+
+        return run_perspectives_parallel(
+            agent=self,
+            task=task,
+            perspectives=keys,
+            max_workers=self.config.max_parallel_perspectives,
+            build_per_perspective_agent=_build,
+        )
+
     def run(self, task: str) -> AgentResponse:
         """Run one preserved user task through the state-machine router."""
         return self.router.run(task)

--- a/adaptive_agent/cli.py
+++ b/adaptive_agent/cli.py
@@ -70,6 +70,15 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="재개한 pending 세션에 전달할 추가 입력",
     )
+    parser.add_argument(
+        "--perspectives",
+        default=None,
+        help=(
+            "콤마 구분 페르소나 키 (예: r,p,a 또는 researcher,pm,architect). "
+            "지정 시 task를 각 페르소나별로 병렬 실행하고 결과를 묶어서 반환. "
+            "implementer는 거부됨."
+        ),
+    )
     return parser
 
 
@@ -141,6 +150,28 @@ def main(argv: Sequence[str] | None = None) -> int:
         parser.error("사용자 입력 원문 보존을 위해 task 전체를 따옴표로 감싸 하나의 인자로 전달하세요.")
 
     task = args.task[0]
+
+    if args.perspectives:
+        try:
+            results = agent.run_perspectives(task, args.perspectives)
+        except ValueError as exc:
+            if args.json:
+                print(json.dumps({"success": False, "error": str(exc), "action": "perspective_error"}, ensure_ascii=False, indent=2))
+            else:
+                print(f"perspective 실행 실패: {exc}")
+            return 1
+        if args.json:
+            payload = {
+                key: _result_to_dict(response)
+                for key, response in results.items()
+            }
+            print(json.dumps(payload, ensure_ascii=False, indent=2))
+        else:
+            for key, response in results.items():
+                print(f"\n=== [{key}] ===")
+                _print_result(response, as_json=False)
+        return 0
+
     result = agent.run(task)
     _print_result(result, args.json)
     return 0

--- a/adaptive_agent/config.py
+++ b/adaptive_agent/config.py
@@ -32,6 +32,7 @@ class AgentConfig:
     session_dir: Path = Path.cwd() / ".adaptive_agent" / "sessions"
     max_self_corrections: int = 2
     max_router_steps: int = 8
+    max_parallel_perspectives: int = 3
     ollama_timeout_seconds: float = 60.0
     ollama_num_predict: int = 256
     ollama_think: bool = False
@@ -79,6 +80,7 @@ class AgentConfig:
             session_dir=session_dir,
             max_self_corrections=int(os.getenv("ADAPTIVE_AGENT_MAX_SELF_CORRECTIONS", "2")),
             max_router_steps=int(os.getenv("ADAPTIVE_AGENT_MAX_ROUTER_STEPS", "8")),
+            max_parallel_perspectives=int(os.getenv("ADAPTIVE_AGENT_MAX_PARALLEL_PERSPECTIVES", "3")),
             ollama_timeout_seconds=float(os.getenv("OLLAMA_TIMEOUT_SECONDS", "60")),
             ollama_num_predict=int(os.getenv("OLLAMA_NUM_PREDICT", "256")),
             ollama_think=os.getenv("OLLAMA_THINK", "false").strip().lower() in {"1", "true", "yes", "on"},

--- a/adaptive_agent/perspectives.py
+++ b/adaptive_agent/perspectives.py
@@ -1,0 +1,185 @@
+"""Multi-perspective parallel execution (issue #20).
+
+다중 페르소나(연구·PM·아키텍트·리뷰어·QA)가 같은 task를 독립적으로 분석해
+서로 다른 관점의 응답을 한번에 받는 기능. 라우터 자체는 sequential 유지하고,
+"여러 관점 분석"만 옵트인으로 병렬화한다.
+
+설계 결정 (issue #20):
+- implementer는 병렬 호출 금지 (write 충돌). 명시적으로 거부.
+- 페르소나는 LLM에 prepended system prompt로만 구분. 별도 agents/ 클래스
+  추가 안 함 — 페르소나는 본질적으로 다른 관점(prompt prefix)이지 다른
+  실행 흐름이 아니다.
+- ThreadPoolExecutor로 동시 호출. AgentConfig.max_parallel_perspectives
+  (default 3)로 제한.
+- 한 페르소나 실패해도 나머지는 결과 반환 (best-effort).
+"""
+
+from __future__ import annotations
+
+import threading
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import TYPE_CHECKING, Callable
+
+from adaptive_agent.llms.base import LLMClient
+
+if TYPE_CHECKING:
+    from adaptive_agent.agent import AdaptiveAgent, AgentResponse
+
+
+# 페르소나 키 → 시스템 프롬프트. 짧은 영어로 작성해 토큰 절약.
+PERSPECTIVE_PROMPTS: dict[str, str] = {
+    "researcher": (
+        "You are the RESEARCHER perspective. Analyze the user task in light of "
+        "academic references, prior work, and known limitations. Discuss "
+        "feature value vs. risks before any implementation suggestion. Do not "
+        "produce code. Focus on what's worth building and what is overreach."
+    ),
+    "pm": (
+        "You are the PM perspective. Translate the user task into a planning "
+        "document with: (1) idea clarification with goal and expected impact, "
+        "(2) development plan with files/paths and data flow, (3) test plan "
+        "with acceptance criteria as a checklist. Do not produce code."
+    ),
+    "architect": (
+        "You are the ARCHITECT perspective. Define module boundaries, file "
+        "list (modify vs. create), data and control flow, and one-line risks "
+        "with alternatives. Do not produce code. Do not introduce framework "
+        "dependencies (no LangChain, no Claude Agent SDK)."
+    ),
+    "reviewer": (
+        "You are the CODE REVIEWER perspective. Evaluate the user task or the "
+        "diff at hand using exactly these sections: 1) expected risks, 2) "
+        "limitations, 3) what was done well, 4) what to keep, 5) improvements "
+        "ranked Must fix / Should fix / Nice to have. Each call out a file or "
+        "function. Do not rewrite code."
+    ),
+    "qa": (
+        "You are the QA perspective. Turn the user task or change set into a "
+        "concrete acceptance-criteria checklist. Record commands you would "
+        "run, expected output, and pass/fail/partial. Do not change code."
+    ),
+}
+
+# Short aliases used by CLI: --perspectives r,p,a,c,q
+PERSPECTIVE_ALIASES: dict[str, str] = {
+    "r": "researcher",
+    "p": "pm",
+    "a": "architect",
+    "c": "reviewer",
+    "code_reviewer": "reviewer",
+    "q": "qa",
+    "researcher": "researcher",
+    "pm": "pm",
+    "architect": "architect",
+    "reviewer": "reviewer",
+    "qa": "qa",
+}
+
+PERSPECTIVES_FORBIDDEN_FOR_PARALLEL = frozenset({"implementer", "i"})
+
+
+def resolve_perspective_keys(raw: list[str] | str) -> list[str]:
+    """Normalize CLI input (e.g. 'r,p,a' or ['researcher','pm']) to canonical keys."""
+
+    if isinstance(raw, str):
+        tokens = [t.strip() for t in raw.split(",") if t.strip()]
+    else:
+        tokens = [str(t).strip() for t in raw if str(t).strip()]
+
+    resolved: list[str] = []
+    for token in tokens:
+        lowered = token.lower()
+        if lowered in PERSPECTIVES_FORBIDDEN_FOR_PARALLEL:
+            raise ValueError(
+                "implementer 페르소나는 병렬 호출을 지원하지 않습니다 "
+                "(write 충돌 위험). 단독 사용하세요."
+            )
+        if lowered not in PERSPECTIVE_ALIASES:
+            raise ValueError(
+                f"알 수 없는 페르소나: {token!r}. 사용 가능: "
+                + ", ".join(sorted(set(PERSPECTIVE_ALIASES.values())))
+            )
+        canonical = PERSPECTIVE_ALIASES[lowered]
+        if canonical not in resolved:  # dedup, preserve order
+            resolved.append(canonical)
+    if not resolved:
+        raise ValueError("최소 한 개 이상의 페르소나를 지정해야 합니다.")
+    return resolved
+
+
+class _PerspectiveLLM:
+    """LLMClient wrapper that prepends a perspective system prompt.
+
+    Thread-safe: each ``complete`` acquires a per-instance lock around the
+    base call so ``last_usage`` reads correspond to the same call. Real
+    provider clients (OpenAI/Gemini/Ollama) create fresh API clients per
+    call inside ``generate``, so this lock is sufficient for usage tracking
+    correctness without serializing across perspectives.
+
+    ``last_usage`` is forwarded from the base client when available
+    (cost-tracking branch). When the base does not expose usage, this stays
+    ``None`` and the agent simply skips usage recording for the wrapper.
+    """
+
+    def __init__(self, base: LLMClient, system_prefix: str) -> None:
+        self.base = base
+        self.system_prefix = system_prefix
+        self.last_usage: object | None = None
+        self._lock = threading.Lock()
+
+    def _wrap(self, prompt: str) -> str:
+        return f"{self.system_prefix}\n\n----\n\n{prompt}"
+
+    def generate(self, prompt: str) -> str:
+        return self.complete(prompt)
+
+    def complete(self, prompt: str) -> str:
+        with self._lock:
+            result = self.base.complete(self._wrap(prompt))
+            self.last_usage = getattr(self.base, "last_usage", None)
+        return result
+
+
+def run_perspectives_parallel(
+    *,
+    agent: "AdaptiveAgent",
+    task: str,
+    perspectives: list[str],
+    max_workers: int,
+    build_per_perspective_agent: Callable[[str, str], "AdaptiveAgent"],
+) -> dict[str, "AgentResponse"]:
+    """Execute ``task`` under each perspective in parallel; return per-key result.
+
+    ``build_per_perspective_agent(perspective_key, system_prefix)`` returns an
+    ``AdaptiveAgent`` instance whose LLM client is wrapped with the
+    perspective's system prefix. The factory is the agent's responsibility
+    so this module stays decoupled from the orchestration class.
+
+    Failures are isolated: a single perspective raising still returns
+    results for the others. The exception is captured as an ``AgentResponse``
+    with ``action='perspective_error'``.
+    """
+
+    from adaptive_agent.agent import AgentResponse  # avoid circular import
+
+    results: dict[str, AgentResponse] = {}
+    workers = max(1, min(max_workers, len(perspectives)))
+
+    def _run_one(key: str) -> tuple[str, "AgentResponse"]:
+        prefix = PERSPECTIVE_PROMPTS[key]
+        sub_agent = build_per_perspective_agent(key, prefix)
+        try:
+            return key, sub_agent.run(task)
+        except Exception as exc:
+            return key, AgentResponse(
+                task=task,
+                output=f"perspective {key} 실행 실패: {exc}",
+                action="perspective_error",
+            )
+
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        futures = [pool.submit(_run_one, key) for key in perspectives]
+        for future in as_completed(futures):
+            key, response = future.result()
+            results[key] = response
+    return results

--- a/tests/test_perspectives.py
+++ b/tests/test_perspectives.py
@@ -1,0 +1,207 @@
+"""Multi-perspective parallel execution 테스트.
+
+#20 — researcher / pm / architect / reviewer / qa 페르소나를 동시에
+호출. implementer는 거부.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+import unittest
+
+from adaptive_agent.agent import AdaptiveAgent
+from adaptive_agent.config import AgentConfig
+from adaptive_agent.perspectives import (
+    PERSPECTIVE_PROMPTS,
+    _PerspectiveLLM,
+    resolve_perspective_keys,
+)
+
+
+class _RecordingStubLLM:
+    """매 complete 호출의 prompt를 그대로 기록하는 LLM stub."""
+
+    last_usage = None
+
+    def __init__(self, response: str = '{"action":"respond","response":"ok"}'):
+        self.response = response
+        self.prompts: list[str] = []
+        self._lock = threading.Lock()
+
+    def complete(self, prompt: str) -> str:
+        with self._lock:
+            self.prompts.append(prompt)
+        return self.response
+
+    def generate(self, prompt: str) -> str:
+        return self.complete(prompt)
+
+
+class _SlowLLM(_RecordingStubLLM):
+    """delay seconds slept inside each call to verify parallelism."""
+
+    def __init__(self, delay: float, response: str = '{"action":"respond","response":"slow"}'):
+        super().__init__(response)
+        self.delay = delay
+
+    def complete(self, prompt: str) -> str:
+        time.sleep(self.delay)
+        return super().complete(prompt)
+
+
+class ResolvePerspectiveKeysTest(unittest.TestCase):
+    def test_short_aliases(self) -> None:
+        self.assertEqual(
+            resolve_perspective_keys("r,p,a,c,q"),
+            ["researcher", "pm", "architect", "reviewer", "qa"],
+        )
+
+    def test_full_names(self) -> None:
+        self.assertEqual(
+            resolve_perspective_keys(["researcher", "qa"]),
+            ["researcher", "qa"],
+        )
+
+    def test_dedup_preserves_order(self) -> None:
+        self.assertEqual(resolve_perspective_keys("r,p,r,a,p"), ["researcher", "pm", "architect"])
+
+    def test_empty_input_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            resolve_perspective_keys("")
+        with self.assertRaises(ValueError):
+            resolve_perspective_keys([])
+
+    def test_unknown_key_rejected(self) -> None:
+        with self.assertRaises(ValueError) as ctx:
+            resolve_perspective_keys("xyz")
+        self.assertIn("xyz", str(ctx.exception))
+
+    def test_implementer_rejected(self) -> None:
+        for key in ("implementer", "i", "IMPLEMENTER"):
+            with self.subTest(key=key):
+                with self.assertRaises(ValueError) as ctx:
+                    resolve_perspective_keys(key)
+                self.assertIn("implementer", str(ctx.exception))
+
+
+class PerspectiveLLMWrapperTest(unittest.TestCase):
+    def test_wraps_prompt_with_system_prefix(self) -> None:
+        base = _RecordingStubLLM()
+        wrapped = _PerspectiveLLM(base, system_prefix="You are PM.")
+
+        wrapped.complete("user task here")
+
+        self.assertEqual(len(base.prompts), 1)
+        self.assertIn("You are PM.", base.prompts[0])
+        self.assertIn("user task here", base.prompts[0])
+
+    def test_propagates_last_usage_from_base(self) -> None:
+        # base가 last_usage를 채우는 경우(예: cost-tracking 브랜치 머지 후),
+        # wrapper는 그 값을 그대로 노출해야 한다. 여기서는 일반 객체로 시뮬.
+        class _UsagePayload:
+            input_tokens = 10
+            output_tokens = 5
+
+        base = _RecordingStubLLM()
+        base.last_usage = _UsagePayload()
+        wrapped = _PerspectiveLLM(base, system_prefix="X")
+        wrapped.complete("hi")
+        self.assertIs(wrapped.last_usage, base.last_usage)
+
+
+class RunPerspectivesTest(unittest.TestCase):
+    def test_returns_one_response_per_perspective(self) -> None:
+        agent = AdaptiveAgent(config=AgentConfig(), llm_client=_RecordingStubLLM())
+        results = agent.run_perspectives("아키텍처 검토 부탁", "r,p,a")
+
+        self.assertEqual(set(results.keys()), {"researcher", "pm", "architect"})
+        for key, resp in results.items():
+            with self.subTest(perspective=key):
+                self.assertEqual(resp.task, "아키텍처 검토 부탁")
+
+    def test_each_perspective_uses_different_prompt_prefix(self) -> None:
+        # 각 perspective가 독립된 wrapped LLM을 받으므로 base에 누적되는
+        # 프롬프트의 접두 system 메시지가 perspective마다 다르다.
+        recorded_per_perspective: dict[str, list[str]] = {}
+        lock = threading.Lock()
+
+        class _CapturingLLM:
+            last_usage = None
+
+            def complete(self, prompt: str) -> str:
+                # 어느 perspective의 시스템 프롬프트가 들어있는지 기록
+                with lock:
+                    for key, system_text in PERSPECTIVE_PROMPTS.items():
+                        marker = system_text.split(".")[0][:30]  # 첫 문장 일부
+                        if marker in prompt:
+                            recorded_per_perspective.setdefault(key, []).append(prompt)
+                            break
+                return '{"action":"respond","response":"acknowledged"}'
+
+            def generate(self, prompt: str) -> str:
+                return self.complete(prompt)
+
+        agent = AdaptiveAgent(config=AgentConfig(), llm_client=_CapturingLLM())
+        agent.run_perspectives("task", ["researcher", "pm", "architect"])
+
+        self.assertIn("researcher", recorded_per_perspective)
+        self.assertIn("pm", recorded_per_perspective)
+        self.assertIn("architect", recorded_per_perspective)
+
+    def test_implementer_rejected_via_run_perspectives(self) -> None:
+        agent = AdaptiveAgent(config=AgentConfig(), llm_client=_RecordingStubLLM())
+        with self.assertRaises(ValueError):
+            agent.run_perspectives("x", "implementer")
+        with self.assertRaises(ValueError):
+            agent.run_perspectives("x", "r,implementer")
+
+    def test_parallel_execution_is_actually_parallel(self) -> None:
+        # 3 perspectives * 0.2s sleep — sequential would take ~0.6s, parallel < 0.4s
+        delay = 0.2
+        agent = AdaptiveAgent(
+            config=AgentConfig(max_parallel_perspectives=3),
+            llm_client=_SlowLLM(delay=delay),
+        )
+
+        started = time.monotonic()
+        results = agent.run_perspectives("측정", "r,p,a")
+        elapsed = time.monotonic() - started
+
+        self.assertEqual(len(results), 3)
+        self.assertLess(elapsed, delay * 2.5, f"병렬 실행이 너무 느림 ({elapsed:.2f}s)")
+
+    def test_one_perspective_failure_does_not_kill_others(self) -> None:
+        class _PartialFailLLM:
+            last_usage = None
+
+            def __init__(self):
+                self.calls = 0
+                self._lock = threading.Lock()
+
+            def complete(self, prompt: str) -> str:
+                with self._lock:
+                    self.calls += 1
+                # researcher의 prompt prefix를 받으면 실패시킴
+                if "RESEARCHER perspective" in prompt:
+                    raise RuntimeError("researcher boom")
+                return '{"action":"respond","response":"ok"}'
+
+            def generate(self, prompt: str) -> str:
+                return self.complete(prompt)
+
+        agent = AdaptiveAgent(config=AgentConfig(), llm_client=_PartialFailLLM())
+        results = agent.run_perspectives("실패 격리", "r,p,a")
+
+        # 실패 격리: 모든 perspective가 결과를 반환해야 함 (실패도 격리된 결과로)
+        self.assertEqual(set(results.keys()), {"researcher", "pm", "architect"})
+        # researcher는 LLM 예외로 실패 — router가 이를 llm_error로 분류하거나
+        # 우리 perspective wrapper가 perspective_error로 잡거나 둘 다 OK
+        self.assertIn(results["researcher"].action, {"llm_error", "perspective_error"})
+        # 나머지는 정상 응답 (action="llm")
+        self.assertEqual(results["pm"].action, "llm")
+        self.assertEqual(results["architect"].action, "llm")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

5개 페르소나(researcher / pm / architect / reviewer / qa)가 같은 task를 동시에 분석. ThreadPoolExecutor 기반 병렬, 한 페르소나 실패도 나머지는 결과 반환.

## 관련 이슈

Closes #20

## 변경 사항

신규 \`adaptive_agent/perspectives.py\`:
- \`PERSPECTIVE_PROMPTS\` (5종 영어 시스템 prompt) + alias 매핑
- \`resolve_perspective_keys\` (dedup, implementer 거부)
- \`_PerspectiveLLM\` (thread-safe wrapper + last_usage 전파)
- \`run_perspectives_parallel\` (ThreadPoolExecutor + 격리된 실패 처리)

\`AdaptiveAgent.run_perspectives(task, perspectives)\`:
- 각 perspective마다 wrapped LLM + 새 AdaptiveAgent 인스턴스
- registry/sandbox는 공유 (heavy resource)
- router/state는 격리

CLI: \`--perspectives r,p,a\` (단축/풀네임 모두 OK)

\`AgentConfig.max_parallel_perspectives = 3\` + env

## 결정 (재확인)

- implementer 거부: write 충돌 위험
- 라우터 자체는 sequential 유지 (전이 단순성, HITL 흐름 보호)

## 테스트 (13 신규)

- [x] 키 해석: 단축/풀네임/dedup/empty/unknown/implementer 거부
- [x] _PerspectiveLLM: 시스템 prefix wrap + last_usage 전파
- [x] run_perspectives: 결과 dict 일치, 페르소나마다 다른 prompt
- [x] 병렬성 측정: 3페르소나 0.2s sleep < 0.4s 총 시간 (sequential은 0.6s)
- [x] 격리: 한 페르소나 LLM 예외 → 나머지 정상

\`\`\`
$ python -m unittest discover -s tests
Ran 138 tests in 1.372s — OK
\`\`\`

## Base

\`feature/agent-core-stabilization\` (PR #21).