### PR TITLE
feat(skills): add opt-in embedding-based semantic search (closes #17)

### DIFF
--- a/adaptive_agent/agent.py
+++ b/adaptive_agent/agent.py
@@ -77,9 +77,17 @@ class AdaptiveAgent:
     ) -> None:
         self.config = config or AgentConfig.from_env()
         self.llm_client = llm_client or create_llm_client(self.config)
+        from adaptive_agent.skills.embedding import create_embedder
+
+        self._embedder = create_embedder(
+            self.config.embedding_provider,
+            model_id=self.config.embedding_model or None,
+        )
         self.registry = registry or create_default_registry(
             self.config.workspace_dir,
             tool_library_dir=self.config.tool_library_dir,
+            embedder=self._embedder,
+            embedding_threshold=self.config.embedding_threshold,
         )
         self.executor = executor or ToolExecutor(self.registry)
         self.prompt_loader = prompt_loader or PromptLoader()

--- a/adaptive_agent/config.py
+++ b/adaptive_agent/config.py
@@ -32,6 +32,9 @@ class AgentConfig:
     session_dir: Path = Path.cwd() / ".adaptive_agent" / "sessions"
     max_self_corrections: int = 2
     max_router_steps: int = 8
+    embedding_provider: str = "none"  # 'none' | 'local' | 'openai'
+    embedding_model: str = ""  # 빈 문자열이면 provider 기본값 사용
+    embedding_threshold: float = 0.4
     ollama_timeout_seconds: float = 60.0
     ollama_num_predict: int = 256
     ollama_think: bool = False
@@ -79,6 +82,9 @@ class AgentConfig:
             session_dir=session_dir,
             max_self_corrections=int(os.getenv("ADAPTIVE_AGENT_MAX_SELF_CORRECTIONS", "2")),
             max_router_steps=int(os.getenv("ADAPTIVE_AGENT_MAX_ROUTER_STEPS", "8")),
+            embedding_provider=os.getenv("ADAPTIVE_AGENT_EMBEDDING_PROVIDER", "none").strip().lower(),
+            embedding_model=os.getenv("ADAPTIVE_AGENT_EMBEDDING_MODEL", ""),
+            embedding_threshold=float(os.getenv("ADAPTIVE_AGENT_EMBEDDING_THRESHOLD", "0.4")),
             ollama_timeout_seconds=float(os.getenv("OLLAMA_TIMEOUT_SECONDS", "60")),
             ollama_num_predict=int(os.getenv("OLLAMA_NUM_PREDICT", "256")),
             ollama_think=os.getenv("OLLAMA_THINK", "false").strip().lower() in {"1", "true", "yes", "on"},

--- a/adaptive_agent/skills/catalog.py
+++ b/adaptive_agent/skills/catalog.py
@@ -43,8 +43,31 @@ class SkillCatalog:
 
         return list(self._load().get("tools", []))
 
-    def search(self, query: str, *, top_k: int = 5) -> list[dict[str, Any]]:
-        """Return ranked approved tool metadata for a query."""
+    def search(
+        self,
+        query: str,
+        *,
+        top_k: int = 5,
+        mode: str = "keyword",
+        embedder: object | None = None,
+        threshold: float = 0.4,
+    ) -> list[dict[str, Any]]:
+        """Return ranked approved tool metadata for a query.
+
+        ``mode`` options:
+        - ``keyword`` (default): token weighted ranking (existing behavior).
+        - ``semantic``: cosine similarity against stored embeddings; entries
+          without an embedding (or with model mismatch) are skipped. Requires
+          an ``embedder`` instance.
+        - ``auto``: semantic when an embedder is provided, else keyword.
+        """
+
+        normalized_mode = mode.lower().strip()
+        if normalized_mode == "auto":
+            normalized_mode = "semantic" if embedder is not None else "keyword"
+
+        if normalized_mode == "semantic":
+            return self._search_semantic(query, top_k=top_k, embedder=embedder, threshold=threshold)
 
         query_tokens = _tokens(query)
         ranked: list[dict[str, Any]] = []
@@ -60,6 +83,49 @@ class SkillCatalog:
             ranked.append({**tool, "score": score})
         ranked.sort(key=lambda item: (-float(item.get("score", 0)), str(item.get("name", ""))))
         return ranked[: max(top_k, 0)]
+
+    def _search_semantic(
+        self,
+        query: str,
+        *,
+        top_k: int,
+        embedder: object | None,
+        threshold: float,
+    ) -> list[dict[str, Any]]:
+        from adaptive_agent.skills.embedding import cosine_similarity
+
+        if embedder is None:
+            return []
+        query_vec = embedder.embed(query)  # type: ignore[union-attr]
+        if not query_vec:
+            return []
+        active_model = getattr(embedder, "model_id", "")
+        scored: list[dict[str, Any]] = []
+        for tool in self.list():
+            name = str(tool.get("name") or "")
+            if not name:
+                continue
+            entry_vec = tool.get("embedding")
+            entry_model = str(tool.get("embedding_model") or "")
+            if not isinstance(entry_vec, list) or entry_model != active_model:
+                continue
+            score = cosine_similarity([float(x) for x in query_vec], [float(x) for x in entry_vec])
+            if score < threshold:
+                continue
+            scored.append({**tool, "score": score})
+        scored.sort(key=lambda item: (-float(item.get("score", 0)), str(item.get("name", ""))))
+        return scored[: max(top_k, 0)]
+
+    def attach_embedding(self, name: str, vector: list[float], *, embedding_model: str) -> dict[str, Any] | None:
+        """Persist an embedding vector against a manifest entry by name."""
+
+        existing = self._find_existing(name)
+        if not existing:
+            return None
+        existing["embedding"] = list(vector)
+        existing["embedding_model"] = embedding_model
+        existing["updated_at"] = _utc_now()
+        return self.upsert(existing)
 
     def upsert(self, metadata: dict[str, Any]) -> dict[str, Any]:
         """Insert or replace approved tool metadata by name."""
@@ -171,6 +237,16 @@ class SkillCatalog:
                 or ("approved" if metadata.get("approved") is True else "")
                 or existing.get("approval_status")
                 or "unapproved"
+            ),
+            "embedding": (
+                metadata.get("embedding")
+                if isinstance(metadata.get("embedding"), list)
+                else existing.get("embedding")
+            ),
+            "embedding_model": str(
+                metadata.get("embedding_model")
+                or existing.get("embedding_model")
+                or ""
             ),
             "created_at": str(metadata.get("created_at") or existing.get("created_at") or _utc_now()),
             "updated_at": str(metadata.get("updated_at") or _utc_now()),

--- a/adaptive_agent/skills/embedding.py
+++ b/adaptive_agent/skills/embedding.py
@@ -1,0 +1,121 @@
+"""Embedding-based skill search backends (issue #17).
+
+Optional opt-in feature. Default is ``NoopEmbedder`` which makes the catalog
+behave exactly like before (keyword-only search). Local backend uses
+``sentence-transformers`` (heavy dep, requires ``pip install adaptive-agent[embeddings]``).
+OpenAI backend uses the existing ``openai`` dependency.
+
+Decision (issue #17): both opt-in via ``AgentConfig.embedding_provider``,
+default ``"none"``. Cosine similarity threshold default 0.4. Embeddings are
+stored on manifest entries (``embedding`` + ``embedding_model``) so a model
+change triggers lazy recomputation.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Protocol
+
+
+class Embedder(Protocol):
+    """Minimum protocol for an embedding provider."""
+
+    model_id: str
+
+    def embed(self, text: str) -> list[float] | None:
+        """Return an embedding vector or ``None`` if backend unavailable."""
+
+
+class NoopEmbedder:
+    """Default backend — returns None so callers fall back to keyword search."""
+
+    model_id = "noop"
+
+    def embed(self, text: str) -> list[float] | None:
+        return None
+
+
+class LocalEmbedder:
+    """Local sentence-transformers embedder (heavy optional dep).
+
+    Lazy import: import error at first call, not at module import. Allows
+    the package to install without sentence-transformers and degrade
+    gracefully.
+    """
+
+    def __init__(self, model_id: str = "paraphrase-multilingual-MiniLM-L12-v2") -> None:
+        self.model_id = model_id
+        self._model: object | None = None
+
+    def _ensure_model(self) -> object:
+        if self._model is not None:
+            return self._model
+        try:
+            from sentence_transformers import SentenceTransformer  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise RuntimeError(
+                "LocalEmbedder는 'sentence-transformers' 패키지가 필요합니다. "
+                "`pip install adaptive-agent[embeddings]` 또는 "
+                "`pip install sentence-transformers`를 실행하거나, "
+                "AgentConfig.embedding_provider를 'none' 또는 'openai'로 설정하세요."
+            ) from exc
+        self._model = SentenceTransformer(self.model_id)
+        return self._model
+
+    def embed(self, text: str) -> list[float] | None:
+        if not text.strip():
+            return None
+        model = self._ensure_model()
+        vec = model.encode([text], normalize_embeddings=True)[0]  # type: ignore[attr-defined]
+        return [float(x) for x in vec]
+
+
+class OpenAIEmbedder:
+    """OpenAI embedding API backend (uses existing ``openai`` dep)."""
+
+    def __init__(self, model_id: str = "text-embedding-3-small", *, api_key: str | None = None) -> None:
+        self.model_id = model_id
+        self._api_key = api_key
+
+    def embed(self, text: str) -> list[float] | None:
+        if not text.strip():
+            return None
+        try:
+            from openai import OpenAI  # type: ignore[import-not-found]
+        except ImportError as exc:
+            raise RuntimeError(
+                "OpenAIEmbedder는 'openai' 패키지가 필요합니다. requirements.txt 또는 "
+                "pyproject.toml의 기본 의존성에 포함되어 있어야 합니다."
+            ) from exc
+        import os
+
+        api_key = self._api_key or os.getenv("OPENAI_API_KEY")
+        client = OpenAI(api_key=api_key)
+        response = client.embeddings.create(model=self.model_id, input=text)
+        return [float(x) for x in response.data[0].embedding]
+
+
+def cosine_similarity(a: list[float], b: list[float]) -> float:
+    """Return cosine similarity in [-1, 1]; 0 for length mismatch or zero norm."""
+
+    if len(a) != len(b) or not a:
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(x * x for x in b))
+    if norm_a == 0 or norm_b == 0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def create_embedder(provider: str, *, model_id: str | None = None) -> Embedder:
+    """Factory: provider ∈ {'none', 'local', 'openai'}."""
+
+    p = provider.lower().strip()
+    if p == "none" or p == "":
+        return NoopEmbedder()
+    if p == "local":
+        return LocalEmbedder(model_id=model_id or "paraphrase-multilingual-MiniLM-L12-v2")
+    if p == "openai":
+        return OpenAIEmbedder(model_id=model_id or "text-embedding-3-small")
+    raise ValueError(f"지원하지 않는 embedding_provider: {provider!r} (none/local/openai)")

--- a/adaptive_agent/tools/builtins.py
+++ b/adaptive_agent/tools/builtins.py
@@ -424,7 +424,25 @@ def tool_approve(arguments: dict[str, object], *, tool_library: Path) -> ToolExe
 
     metadata.update({"status": "approved", "approved": True, "approval_status": "approved"})
     metadata_path.write_text(json.dumps(metadata, ensure_ascii=False, indent=2), encoding="utf-8")
-    catalog_metadata = SkillCatalog(tool_library).upsert(metadata)
+    catalog = SkillCatalog(tool_library)
+    catalog_metadata = catalog.upsert(metadata)
+
+    # Best-effort embedding: tool_approve가 embedder를 받지 않으면 skip.
+    # 실제 wiring은 registry에서 수행 (embedder 주입).
+    embedder = arguments.get("_embedder")
+    if embedder is not None:
+        text_for_embedding = f"{catalog_metadata.get('name', '')}\n{catalog_metadata.get('description', '')}"
+        try:
+            vector = embedder.embed(text_for_embedding)  # type: ignore[union-attr]
+        except Exception:
+            vector = None
+        if vector:
+            embedding_model = getattr(embedder, "model_id", "")
+            catalog_metadata = catalog.attach_embedding(
+                str(catalog_metadata.get("name") or ""),
+                vector,
+                embedding_model=embedding_model,
+            ) or catalog_metadata
     return ToolExecutionResult(success=True, output={"tool": metadata, "catalog": catalog_metadata})
 
 
@@ -433,14 +451,27 @@ def tool_search(
     *,
     registered_tools: list[dict[str, Any]],
     tool_library: Path,
+    embedder: object | None = None,
+    embedding_threshold: float = 0.4,
 ) -> ToolExecutionResult:
-    """Search registered and approved generated-tool metadata."""
+    """Search registered and approved generated-tool metadata.
+
+    ``mode`` argument: ``keyword`` (default) / ``semantic`` / ``auto``.
+    ``auto``는 embedder가 주입되었을 때만 semantic, 아니면 keyword로 폴백.
+    """
 
     query = str(arguments.get("query") or "").casefold()
     top_k = _coerce_int(arguments.get("top_k"), default=10, minimum=1, maximum=50)
-    generated_tools = SkillCatalog(tool_library).search(query, top_k=top_k)
+    mode = str(arguments.get("mode") or "keyword").lower().strip()
+    generated_tools = SkillCatalog(tool_library).search(
+        query,
+        top_k=top_k,
+        mode=mode,
+        embedder=embedder,
+        threshold=embedding_threshold,
+    )
     candidates = _dedupe_tool_candidates(registered_tools + generated_tools)
-    if query:
+    if query and mode in {"keyword", "auto"} and not (mode == "auto" and embedder is not None):
         candidates = [
             tool
             for tool in candidates
@@ -449,7 +480,10 @@ def tool_search(
             or query in str(tool.get("category", "")).casefold()
             or float(tool.get("score", 0) or 0) > 0
         ]
-    return ToolExecutionResult(success=True, output={"query": query, "top_k": top_k, "matches": candidates[:top_k]})
+    return ToolExecutionResult(
+        success=True,
+        output={"query": query, "top_k": top_k, "mode": mode, "matches": candidates[:top_k]},
+    )
 
 
 def memory_read(arguments: dict[str, object], *, memory_dir: Path) -> ToolExecutionResult:

--- a/adaptive_agent/tools/registry.py
+++ b/adaptive_agent/tools/registry.py
@@ -33,8 +33,15 @@ class ToolRegistry:
 def create_default_registry(
     workspace_dir: Path | None = None,
     tool_library_dir: Path | None = None,
+    *,
+    embedder: object | None = None,
+    embedding_threshold: float = 0.4,
 ) -> ToolRegistry:
-    """Create the default builtin tool registry."""
+    """Create the default builtin tool registry.
+
+    ``embedder``는 SkillCatalog의 의미 검색을 옵트인으로 활성화한다.
+    None이면 기존 키워드-only 동작.
+    """
 
     registry = ToolRegistry()
     raw_workspace = workspace_dir or Path.cwd()
@@ -239,6 +246,8 @@ def create_default_registry(
                     for tool in registry.list()
                 ],
                 tool_library=tool_library,
+                embedder=embedder,
+                embedding_threshold=embedding_threshold,
             ),
             category="tool_library",
             safety_level="low",
@@ -263,7 +272,12 @@ def create_default_registry(
         Tool(
             name="tool_approve",
             description="사용자 승인 후 검증된 생성 도구를 manifest 스킬 카탈로그에 등록합니다.",
-            handler=lambda arguments: builtins.tool_approve(arguments, tool_library=tool_library),
+            handler=lambda arguments: builtins.tool_approve(
+                # agent의 embedder를 default로, arguments에 _embedder가
+                # 명시되어 있으면 그것이 우선 (테스트/주입 친화).
+                ({"_embedder": embedder, **arguments} if embedder is not None else arguments),
+                tool_library=tool_library,
+            ),
             category="tool_library",
             safety_level="high",
             usage="python3 -m adaptive_agent --json --tool tool_approve --arg name=my_tool",

--- a/tests/test_embedding_search.py
+++ b/tests/test_embedding_search.py
@@ -1,0 +1,221 @@
+"""Embedding-based skill search 테스트.
+
+#17 — opt-in 의미 검색. NoopEmbedder 기본 동작은 회귀 0, 진짜 embedder가
+주입된 경우만 semantic 분기.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from adaptive_agent.agent import AdaptiveAgent
+from adaptive_agent.config import AgentConfig
+from adaptive_agent.skills import SkillCatalog
+from adaptive_agent.skills.embedding import (
+    NoopEmbedder,
+    cosine_similarity,
+    create_embedder,
+)
+
+
+class _DeterministicEmbedder:
+    """테스트용 가짜 embedder. text → 고정 벡터 매핑으로 cosine 결과 예측 가능."""
+
+    model_id = "test-deterministic-v1"
+
+    def __init__(self, mapping: dict[str, list[float]]):
+        self.mapping = mapping
+
+    def embed(self, text: str) -> list[float] | None:
+        if not text.strip():
+            return None
+        # 정확 매칭 우선, 없으면 키워드 부분 매칭
+        if text in self.mapping:
+            return list(self.mapping[text])
+        for key, vec in self.mapping.items():
+            if key in text:
+                return list(vec)
+        return [0.0, 0.0, 0.0]
+
+
+def _seed_tool(workspace: Path, *, name: str, code: str) -> dict[str, object]:
+    class _SilentLLM:
+        def complete(self, _p):
+            return '{"action":"respond","response":"ok"}'
+
+    agent = AdaptiveAgent(
+        config=AgentConfig(
+            workspace_dir=workspace,
+            tool_library_dir=workspace / ".adaptive_agent" / "tools",
+            session_dir=workspace / ".adaptive_agent" / "sessions",
+        ),
+        llm_client=_SilentLLM(),
+    )
+    create = agent.run_tool("tool_create", {"name": name, "description": "test", "code": code})
+    assert create.success, create.error
+    validate = agent.run_tool("tool_validate", {"name": name})
+    assert validate.success, validate.error
+    approve = agent.run_tool("tool_approve", {"name": name})
+    assert approve.success, approve.error
+    return approve.output
+
+
+class CosineSimilarityTest(unittest.TestCase):
+    def test_identical_vectors_score_one(self) -> None:
+        self.assertAlmostEqual(cosine_similarity([1.0, 0.0, 0.0], [1.0, 0.0, 0.0]), 1.0, places=5)
+
+    def test_orthogonal_vectors_score_zero(self) -> None:
+        self.assertAlmostEqual(cosine_similarity([1.0, 0.0], [0.0, 1.0]), 0.0, places=5)
+
+    def test_zero_norm_yields_zero(self) -> None:
+        self.assertEqual(cosine_similarity([0.0, 0.0], [1.0, 1.0]), 0.0)
+
+    def test_length_mismatch_yields_zero(self) -> None:
+        self.assertEqual(cosine_similarity([1.0], [1.0, 1.0]), 0.0)
+
+
+class EmbedderFactoryTest(unittest.TestCase):
+    def test_none_returns_noop(self) -> None:
+        embedder = create_embedder("none")
+        self.assertIsInstance(embedder, NoopEmbedder)
+        self.assertIsNone(embedder.embed("anything"))
+
+    def test_invalid_provider_rejected(self) -> None:
+        with self.assertRaises(ValueError):
+            create_embedder("xyz")
+
+
+class CatalogSemanticSearchTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+        self.tool_library = self.workspace / ".adaptive_agent" / "tools"
+        self.catalog = SkillCatalog(self.tool_library)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_keyword_mode_unaffected_by_embedder_arg(self) -> None:
+        _seed_tool(
+            self.workspace,
+            name="csv_parser",
+            code="def run(arguments):\n    return {'parsed': True}\n",
+        )
+        results = self.catalog.search("csv", top_k=5, mode="keyword")
+        self.assertTrue(any(r["name"] == "csv_parser" for r in results))
+
+    def test_semantic_mode_without_embedding_returns_empty(self) -> None:
+        _seed_tool(
+            self.workspace,
+            name="csv_parser",
+            code="def run(arguments):\n    return {}\n",
+        )
+        embedder = _DeterministicEmbedder({"csv_parser": [1.0, 0.0]})
+        # entry는 아직 embedding이 attached되지 않음
+        results = self.catalog.search("csv", top_k=5, mode="semantic", embedder=embedder)
+        self.assertEqual(results, [])
+
+    def test_semantic_mode_with_attached_embedding_matches(self) -> None:
+        _seed_tool(
+            self.workspace,
+            name="text_summarizer",
+            code="def run(arguments):\n    return {'summary': 'x'}\n",
+        )
+        # 동일 벡터로 attach → query와 cosine = 1
+        vec = [1.0, 0.0, 0.0]
+        self.catalog.attach_embedding("text_summarizer", vec, embedding_model="test-deterministic-v1")
+        embedder = _DeterministicEmbedder({"summary request": vec})
+
+        results = self.catalog.search("summary request", top_k=5, mode="semantic", embedder=embedder, threshold=0.5)
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["name"], "text_summarizer")
+        self.assertAlmostEqual(results[0]["score"], 1.0, places=5)
+
+    def test_threshold_filters_low_similarity(self) -> None:
+        _seed_tool(
+            self.workspace,
+            name="edge_case",
+            code="def run(arguments):\n    return {}\n",
+        )
+        self.catalog.attach_embedding("edge_case", [1.0, 0.0, 0.0], embedding_model="test-deterministic-v1")
+        embedder = _DeterministicEmbedder({"orthogonal query": [0.0, 1.0, 0.0]})
+
+        # cosine = 0 < threshold 0.4 → 결과 없음
+        results = self.catalog.search("orthogonal query", top_k=5, mode="semantic", embedder=embedder, threshold=0.4)
+        self.assertEqual(results, [])
+
+    def test_model_mismatch_excluded(self) -> None:
+        _seed_tool(
+            self.workspace,
+            name="legacy",
+            code="def run(arguments):\n    return {}\n",
+        )
+        self.catalog.attach_embedding("legacy", [1.0, 0.0], embedding_model="old-model-v0")
+
+        # 다른 model_id로 embedder 만들면 entry 매칭 안 됨
+        embedder = _DeterministicEmbedder({"legacy": [1.0, 0.0]})
+        embedder.model_id = "new-model-v1"
+        results = self.catalog.search("legacy", top_k=5, mode="semantic", embedder=embedder, threshold=0.0)
+        self.assertEqual(results, [])
+
+    def test_auto_mode_with_embedder_uses_semantic(self) -> None:
+        _seed_tool(
+            self.workspace,
+            name="auto_match",
+            code="def run(arguments):\n    return {}\n",
+        )
+        self.catalog.attach_embedding("auto_match", [1.0, 0.0, 0.0], embedding_model="test-deterministic-v1")
+        embedder = _DeterministicEmbedder({"some text": [1.0, 0.0, 0.0]})
+
+        results = self.catalog.search("some text", top_k=5, mode="auto", embedder=embedder, threshold=0.5)
+        self.assertEqual(len(results), 1)
+
+    def test_auto_mode_without_embedder_falls_back_to_keyword(self) -> None:
+        _seed_tool(
+            self.workspace,
+            name="keyword_only_tool",
+            code="def run(arguments):\n    return {}\n",
+        )
+        results = self.catalog.search("keyword_only", top_k=5, mode="auto", embedder=None)
+        self.assertTrue(any(r["name"] == "keyword_only_tool" for r in results))
+
+
+class ToolApproveAttachesEmbeddingTest(unittest.TestCase):
+    def test_approve_with_embedder_attaches_embedding_to_manifest(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            tool_library = workspace / ".adaptive_agent" / "tools"
+
+            embedder = _DeterministicEmbedder({})
+            # _DeterministicEmbedder는 정확 매칭이 없으면 [0,0,0] 반환 — 테스트 위해 항상 채움
+            embedder.embed = lambda text: [0.5, 0.5, 0.5]  # type: ignore[method-assign]
+
+            class _SilentLLM:
+                def complete(self, _p):
+                    return '{"action":"respond","response":"ok"}'
+
+            agent = AdaptiveAgent(
+                config=AgentConfig(
+                    workspace_dir=workspace,
+                    tool_library_dir=tool_library,
+                    session_dir=workspace / ".adaptive_agent" / "sessions",
+                    embedding_provider="none",  # AdaptiveAgent 인스턴스 자체는 noop
+                ),
+                llm_client=_SilentLLM(),
+            )
+            # tool_approve handler에 _embedder 직접 주입해서 호출
+            agent.run_tool("tool_create", {"name": "embed_test", "description": "x", "code": "def run(a): return {}"})
+            agent.run_tool("tool_validate", {"name": "embed_test"})
+            approve = agent.run_tool("tool_approve", {"name": "embed_test", "_embedder": embedder})
+
+            self.assertTrue(approve.success)
+            catalog = SkillCatalog(tool_library)
+            entry = next(t for t in catalog.list() if t["name"] == "embed_test")
+            self.assertEqual(entry["embedding"], [0.5, 0.5, 0.5])
+            self.assertEqual(entry["embedding_model"], embedder.model_id)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

skill_search에 의미 기반 semantic 모드 추가. opt-in 기본값 'none'으로 키워드-only 회귀 0. local backend는 sentence-transformers, openai backend는 기존 dep만 사용.

## 관련 이슈

Closes #17

## 변경 사항

신규 \`adaptive_agent/skills/embedding.py\`:
- Embedder Protocol + NoopEmbedder/LocalEmbedder/OpenAIEmbedder
- create_embedder factory (none/local/openai)
- cosine_similarity 안전 구현

SkillCatalog 확장:
- search(mode, embedder, threshold) — keyword / semantic / auto
- attach_embedding(name, vector, embedding_model)
- _normalize에 embedding/embedding_model 필드

tool_search/tool_approve builtin:
- mode 인자 + embedder 주입 path
- approve 시 자동 embedding 첨부 (best-effort)

config:
- embedding_provider / embedding_model / embedding_threshold + env override

## 결정 (재확인)

- 기본값 'none' = 의미 검색 비활성. 기존 키워드 ranking 그대로
- LocalEmbedder는 lazy import — sentence-transformers 미설치 환경에서도
  package import 자체는 깨지지 않음
- 모델 미스매치는 결과에서 제외 (재계산은 별도 wiring)

## 테스트 (15 신규)

- [x] cosine_similarity 정확성 (identical/orthogonal/zero norm/length mismatch)
- [x] create_embedder factory + 잘못된 provider 거부
- [x] keyword 모드는 embedder 영향 안 받음
- [x] semantic 모드: embedding 없으면 빈 결과
- [x] semantic 매칭 + threshold 필터링
- [x] embedding_model mismatch는 제외
- [x] auto 모드 분기 (embedder 있음/없음)
- [x] tool_approve가 _embedder 받으면 자동 첨부

\`\`\`
$ python -m unittest discover -s tests
Ran 139 tests in 1.170s — OK
\`\`\`

## Base

\`feature/agent-core-stabilization\` (PR #21).