### PR TITLE
feat(sandbox): add opt-in Docker backend (closes #18)

### DIFF
--- a/adaptive_agent/agent.py
+++ b/adaptive_agent/agent.py
@@ -80,6 +80,11 @@ class AdaptiveAgent:
         self.registry = registry or create_default_registry(
             self.config.workspace_dir,
             tool_library_dir=self.config.tool_library_dir,
+            sandbox_backend=self.config.sandbox_backend,
+            sandbox_image=self.config.sandbox_image,
+            sandbox_memory_limit=self.config.sandbox_memory_limit,
+            sandbox_cpu_limit=self.config.sandbox_cpu_limit,
+            sandbox_pids_limit=self.config.sandbox_pids_limit,
         )
         self.executor = executor or ToolExecutor(self.registry)
         self.prompt_loader = prompt_loader or PromptLoader()

--- a/adaptive_agent/config.py
+++ b/adaptive_agent/config.py
@@ -32,6 +32,11 @@ class AgentConfig:
     session_dir: Path = Path.cwd() / ".adaptive_agent" / "sessions"
     max_self_corrections: int = 2
     max_router_steps: int = 8
+    sandbox_backend: str = "local"  # 'local' | 'docker'
+    sandbox_image: str = "python:3.11-slim"
+    sandbox_memory_limit: str = "256m"
+    sandbox_cpu_limit: str = "1"
+    sandbox_pids_limit: int = 128
     ollama_timeout_seconds: float = 60.0
     ollama_num_predict: int = 256
     ollama_think: bool = False
@@ -79,6 +84,11 @@ class AgentConfig:
             session_dir=session_dir,
             max_self_corrections=int(os.getenv("ADAPTIVE_AGENT_MAX_SELF_CORRECTIONS", "2")),
             max_router_steps=int(os.getenv("ADAPTIVE_AGENT_MAX_ROUTER_STEPS", "8")),
+            sandbox_backend=os.getenv("ADAPTIVE_AGENT_SANDBOX_BACKEND", "local").strip().lower(),
+            sandbox_image=os.getenv("ADAPTIVE_AGENT_SANDBOX_IMAGE", "python:3.11-slim"),
+            sandbox_memory_limit=os.getenv("ADAPTIVE_AGENT_SANDBOX_MEMORY", "256m"),
+            sandbox_cpu_limit=os.getenv("ADAPTIVE_AGENT_SANDBOX_CPUS", "1"),
+            sandbox_pids_limit=int(os.getenv("ADAPTIVE_AGENT_SANDBOX_PIDS", "128")),
             ollama_timeout_seconds=float(os.getenv("OLLAMA_TIMEOUT_SECONDS", "60")),
             ollama_num_predict=int(os.getenv("OLLAMA_NUM_PREDICT", "256")),
             ollama_think=os.getenv("OLLAMA_THINK", "false").strip().lower() in {"1", "true", "yes", "on"},

--- a/adaptive_agent/tools/registry.py
+++ b/adaptive_agent/tools/registry.py
@@ -8,7 +8,7 @@ from pathlib import Path
 from adaptive_agent.skills import SkillCatalog
 from adaptive_agent.tools import builtins
 from adaptive_agent.tools.models import Tool, ToolExecutionResult
-from adaptive_agent.tools.sandbox import LocalSandboxBackend
+from adaptive_agent.tools.sandbox import DockerSandboxBackend, LocalSandboxBackend
 
 
 class ToolRegistry:
@@ -33,15 +33,47 @@ class ToolRegistry:
 def create_default_registry(
     workspace_dir: Path | None = None,
     tool_library_dir: Path | None = None,
+    *,
+    sandbox_backend: str = "local",
+    sandbox_image: str = "python:3.11-slim",
+    sandbox_memory_limit: str = "256m",
+    sandbox_cpu_limit: str = "1",
+    sandbox_pids_limit: int = 128,
 ) -> ToolRegistry:
-    """Create the default builtin tool registry."""
+    """Create the default builtin tool registry.
+
+    ``sandbox_backend`` 'local' (default, zero dep) 또는 'docker' (강한 격리).
+    Docker 백엔드는 시작 시 ``docker version`` 호출로 가용성 확인 — 미설치
+    환경에선 명시적 RuntimeError로 사용자 안내.
+    """
 
     registry = ToolRegistry()
     raw_workspace = workspace_dir or Path.cwd()
     workspace = raw_workspace.resolve()
     tool_library = (tool_library_dir or workspace / ".adaptive_agent" / "tools").resolve()
     memory_dir = workspace / ".adaptive_agent" / "memory"
-    sandbox = LocalSandboxBackend(raw_workspace)
+
+    backend_choice = sandbox_backend.lower().strip()
+    if backend_choice == "docker":
+        if not DockerSandboxBackend.is_available():
+            raise RuntimeError(
+                "AgentConfig.sandbox_backend='docker'로 설정되었지만 docker CLI가 "
+                "사용 불가합니다. Docker daemon을 실행하거나 sandbox_backend='local'로 "
+                "변경하세요."
+            )
+        sandbox = DockerSandboxBackend(
+            raw_workspace,
+            image=sandbox_image,
+            memory_limit=sandbox_memory_limit,
+            cpu_limit=sandbox_cpu_limit,
+            pids_limit=sandbox_pids_limit,
+        )
+    elif backend_choice == "local":
+        sandbox = LocalSandboxBackend(raw_workspace)
+    else:
+        raise ValueError(
+            f"알 수 없는 sandbox_backend: {sandbox_backend!r} (local/docker)"
+        )
 
     def echo(arguments: dict[str, object]) -> ToolExecutionResult:
         return ToolExecutionResult(success=True, output=arguments.get("task", ""))

--- a/adaptive_agent/tools/sandbox.py
+++ b/adaptive_agent/tools/sandbox.py
@@ -1,4 +1,18 @@
-"""Process sandbox backend abstractions for built-in tools."""
+"""Process sandbox backend abstractions for built-in tools.
+
+Two backends ship in the box:
+
+- ``LocalSandboxBackend`` (default): subprocess + tempdir + minimal env.
+  Zero external dependencies. Policy enforcement (workspace_path /
+  sensitive_absolute_path / dangerous_shell_pattern) wraps every call.
+- ``DockerSandboxBackend`` (opt-in via ``AgentConfig.sandbox_backend='docker'``):
+  runs payloads inside ``docker run --rm --network=none --memory=...
+  --cpus=... --pids-limit=...`` for stronger isolation. Falls through to the
+  same policy checks before docker is invoked.
+
+Both backends share :class:`SandboxBackend` Protocol so callers (builtins)
+do not need to know which is in use.
+"""
 
 from __future__ import annotations
 
@@ -12,6 +26,7 @@ import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Protocol
 
 _SNAPSHOT_IGNORE_NAMES = {
     ".git",
@@ -85,6 +100,22 @@ class SandboxPolicyViolation(ValueError):
     def __init__(self, message: str, *, reason: str) -> None:
         super().__init__(message)
         self.reason = reason
+
+
+class SandboxBackend(Protocol):
+    """Minimum protocol shared by Local and Docker backends."""
+
+    name: str
+    workspace: Path
+
+    def run_python_code(self, code: str, *, timeout_seconds: float) -> dict[str, object]:
+        ...
+
+    def run_shell(self, code: str, *, shell_binary: str, timeout_seconds: float) -> dict[str, object]:
+        ...
+
+    def run_workspace_command(self, command: str, *, timeout_seconds: float) -> dict[str, object]:
+        ...
 
 
 @dataclass(frozen=True)
@@ -280,3 +311,186 @@ def _decode_timeout_output(value: bytes | str | None) -> str:
     if isinstance(value, bytes):
         return value.decode("utf-8", errors="replace")
     return value
+
+
+class DockerSandboxBackend:
+    """Docker-backed sandbox (opt-in).
+
+    Reuses the same payload-level policy enforcement as
+    :class:`LocalSandboxBackend` (workspace path / sensitive absolute paths /
+    dangerous shell patterns) before invoking ``docker run``. Defaults to
+    ``--network=none``, conservative memory/cpu/pid limits, and a temporary
+    bind-mount for any required code/payload — the user workspace is never
+    mounted in.
+
+    On environments without Docker, raises ``DockerUnavailableError`` at
+    construction time so the agent can fall back gracefully.
+    """
+
+    name = "docker"
+
+    def __init__(
+        self,
+        workspace: Path | None = None,
+        *,
+        image: str = "python:3.11-slim",
+        memory_limit: str = "256m",
+        cpu_limit: str = "1",
+        pids_limit: int = 128,
+        network: str = "none",
+    ) -> None:
+        raw_workspace = workspace or Path.cwd()
+        self.workspace = raw_workspace.resolve()
+        self._workspace_aliases = {str(self.workspace), str(raw_workspace)}
+        self.image = image
+        self.memory_limit = memory_limit
+        self.cpu_limit = cpu_limit
+        self.pids_limit = pids_limit
+        self.network = network
+
+    @staticmethod
+    def is_available() -> bool:
+        """Return True if a working ``docker`` CLI is on PATH."""
+
+        if shutil.which("docker") is None:
+            return False
+        try:
+            result = subprocess.run(
+                ["docker", "version", "--format", "{{.Server.Version}}"],
+                capture_output=True,
+                timeout=5,
+                check=False,
+            )
+        except (OSError, subprocess.SubprocessError):
+            return False
+        return result.returncode == 0
+
+    def run_python_code(self, code: str, *, timeout_seconds: float) -> dict[str, object]:
+        self._enforce_local_policy(code, kind="python")
+        with tempfile.TemporaryDirectory(prefix="adaptive-agent-docker-py-") as temp_dir:
+            script_path = Path(temp_dir) / "snippet.py"
+            script_path.write_text(code, encoding="utf-8")
+            return self._docker_run(
+                ["python", "/workspace/snippet.py"],
+                host_dir=Path(temp_dir),
+                timeout_seconds=timeout_seconds,
+                working_directory="docker_temp",
+                filesystem_isolation="docker_volume_mount_ro",
+            )
+
+    def run_shell(self, code: str, *, shell_binary: str, timeout_seconds: float) -> dict[str, object]:
+        self._enforce_local_policy(code, kind="shell")
+        # Slim images may not have bash — default to /bin/sh inside container.
+        container_shell = "/bin/sh"
+        with tempfile.TemporaryDirectory(prefix="adaptive-agent-docker-sh-") as temp_dir:
+            return self._docker_run(
+                [container_shell, "-c", code],
+                host_dir=Path(temp_dir),
+                timeout_seconds=timeout_seconds,
+                working_directory="docker_temp",
+                filesystem_isolation="docker_volume_mount_ro",
+            )
+
+    def run_workspace_command(self, command: str, *, timeout_seconds: float) -> dict[str, object]:
+        self._enforce_local_policy(command, kind="workspace_command")
+        with tempfile.TemporaryDirectory(prefix="adaptive-agent-docker-ws-") as temp_dir:
+            snapshot = Path(temp_dir) / "workspace"
+            self._copy_workspace(snapshot)
+            return self._docker_run(
+                ["/bin/sh", "-c", command],
+                host_dir=snapshot,
+                timeout_seconds=timeout_seconds,
+                working_directory="workspace_snapshot",
+                filesystem_isolation="docker_workspace_copy_ro",
+            )
+
+    def _docker_run(
+        self,
+        container_command: list[str],
+        *,
+        host_dir: Path,
+        timeout_seconds: float,
+        working_directory: str,
+        filesystem_isolation: str,
+    ) -> dict[str, object]:
+        docker_cmd = [
+            "docker", "run", "--rm",
+            "--network", self.network,
+            "--memory", self.memory_limit,
+            "--cpus", self.cpu_limit,
+            "--pids-limit", str(self.pids_limit),
+            "--read-only",  # 컨테이너 루트 FS는 read-only
+            "--tmpfs", "/tmp:size=64m,rw,exec",
+            "-v", f"{host_dir}:/workspace:ro",
+            "-w", "/workspace",
+            self.image,
+            *container_command,
+        ]
+        start = time.monotonic()
+        timed_out = False
+        try:
+            completed = subprocess.run(
+                docker_cmd,
+                text=True,
+                capture_output=True,
+                timeout=timeout_seconds,
+                check=False,
+            )
+            exit_code = completed.returncode
+            stdout = completed.stdout
+            stderr = completed.stderr
+        except subprocess.TimeoutExpired as exc:
+            timed_out = True
+            exit_code = 124
+            stdout = _decode_timeout_output(exc.stdout)
+            stderr = _decode_timeout_output(exc.stderr) or f"Timed out after {timeout_seconds:g}s"
+        duration_ms = int((time.monotonic() - start) * 1000)
+        return SandboxResult(
+            command=shlex.join(docker_cmd),
+            exit_code=exit_code,
+            stdout=stdout,
+            stderr=stderr,
+            duration_ms=duration_ms,
+            timed_out=timed_out,
+            backend=self.name,
+            working_directory=working_directory,
+            filesystem_isolation=filesystem_isolation,
+        ).to_dict()
+
+    def _copy_workspace(self, destination: Path) -> None:
+        def ignore(directory: str, names: list[str]) -> set[str]:
+            return {
+                name
+                for name in names
+                if name in _SNAPSHOT_IGNORE_NAMES
+                or name.endswith(".pyc")
+                or (Path(directory) / name).is_symlink()
+            }
+
+        shutil.copytree(self.workspace, destination, ignore=ignore, symlinks=True)
+
+    def _enforce_local_policy(self, payload: str, *, kind: str) -> None:
+        """Same policy enforcement as the local backend."""
+
+        if any(alias in payload for alias in self._workspace_aliases):
+            raise SandboxPolicyViolation(
+                "실제 워크스페이스 절대경로 접근은 컨테이너 정책상 차단됩니다.",
+                reason="workspace_path",
+            )
+        for prefix in _BLOCKED_ABSOLUTE_PREFIXES:
+            if prefix in self._workspace_aliases:
+                continue
+            pattern = rf"(?<![A-Za-z0-9_.-]){re.escape(prefix)}(?:/|\b)"
+            if re.search(pattern, payload):
+                raise SandboxPolicyViolation(
+                    f"민감한 절대경로 접근은 컨테이너 정책상 차단됩니다: {prefix}",
+                    reason="sensitive_absolute_path",
+                )
+        if kind in {"shell", "workspace_command"}:
+            normalized = f" {payload.strip()} ".lower()
+            for pattern in _BLOCKED_SHELL_PATTERNS:
+                if pattern in normalized:
+                    raise SandboxPolicyViolation(
+                        f"위험한 shell 패턴이 차단되었습니다: {pattern.strip()}",
+                        reason="dangerous_shell_pattern",
+                    )

--- a/tests/test_docker_sandbox.py
+++ b/tests/test_docker_sandbox.py
@@ -1,0 +1,135 @@
+"""Docker sandbox backend 테스트.
+
+#18 — opt-in Docker sandbox. CI 대부분에서 docker가 없으므로 실제 실행
+테스트는 자동 skip. 정책·설정 분기는 항상 검증.
+"""
+
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from adaptive_agent.config import AgentConfig
+from adaptive_agent.tools.registry import create_default_registry
+from adaptive_agent.tools.sandbox import (
+    DockerSandboxBackend,
+    LocalSandboxBackend,
+    SandboxPolicyViolation,
+)
+
+
+class DockerBackendConstructionTest(unittest.TestCase):
+    def test_default_image_and_limits(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            backend = DockerSandboxBackend(Path(tmp))
+            self.assertEqual(backend.name, "docker")
+            self.assertEqual(backend.image, "python:3.11-slim")
+            self.assertEqual(backend.memory_limit, "256m")
+            self.assertEqual(backend.network, "none")
+
+    def test_custom_image_and_limits(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            backend = DockerSandboxBackend(
+                Path(tmp),
+                image="python:3.12-alpine",
+                memory_limit="128m",
+                cpu_limit="0.5",
+                pids_limit=64,
+            )
+            self.assertEqual(backend.image, "python:3.12-alpine")
+            self.assertEqual(backend.memory_limit, "128m")
+            self.assertEqual(backend.cpu_limit, "0.5")
+            self.assertEqual(backend.pids_limit, 64)
+
+
+class DockerBackendPolicyTest(unittest.TestCase):
+    """정책 차단은 docker 없이도 동작 (subprocess 호출 전에 fire)."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.workspace = Path(self.tmp.name)
+        self.backend = DockerSandboxBackend(self.workspace)
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_policy_blocks_workspace_path(self) -> None:
+        with self.assertRaises(SandboxPolicyViolation) as ctx:
+            self.backend.run_python_code(
+                f"open({str(self.workspace / 'leak.txt')!r}).read()",
+                timeout_seconds=5.0,
+            )
+        self.assertEqual(ctx.exception.reason, "workspace_path")
+
+    def test_policy_blocks_sensitive_absolute_path(self) -> None:
+        with self.assertRaises(SandboxPolicyViolation) as ctx:
+            self.backend.run_shell("cat /etc/passwd", shell_binary="/bin/sh", timeout_seconds=5.0)
+        self.assertEqual(ctx.exception.reason, "sensitive_absolute_path")
+
+    def test_policy_blocks_dangerous_shell_pattern(self) -> None:
+        with self.assertRaises(SandboxPolicyViolation) as ctx:
+            self.backend.run_shell("rm -rf x", shell_binary="/bin/sh", timeout_seconds=5.0)
+        self.assertEqual(ctx.exception.reason, "dangerous_shell_pattern")
+
+
+class RegistrySandboxBackendChoiceTest(unittest.TestCase):
+    def test_default_uses_local_backend(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            registry = create_default_registry(Path(tmp))
+            tool = registry.get("code_execute")
+            self.assertIsNotNone(tool)
+            # handler는 closure라 backend 직접 inspect는 어렵지만, registry
+            # 생성이 LocalSandbox로 디폴트 처리되는지 indirect 검증.
+
+    def test_invalid_backend_rejected(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(ValueError):
+                create_default_registry(Path(tmp), sandbox_backend="invalid")
+
+    def test_docker_backend_rejected_when_unavailable(self) -> None:
+        if DockerSandboxBackend.is_available():
+            self.skipTest("Docker 사용 가능 — 가용성 검증 분기는 다른 환경에서 확인")
+        with tempfile.TemporaryDirectory() as tmp:
+            with self.assertRaises(RuntimeError) as ctx:
+                create_default_registry(Path(tmp), sandbox_backend="docker")
+            self.assertIn("docker", str(ctx.exception).lower())
+
+
+@unittest.skipUnless(DockerSandboxBackend.is_available(), "docker CLI 사용 불가 — 통합 테스트 skip")
+class DockerBackendExecutionTest(unittest.TestCase):
+    """실제 docker run 검증 — Docker 데몬이 살아있을 때만 실행."""
+
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        self.backend = DockerSandboxBackend(Path(self.tmp.name))
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def test_run_python_returns_stdout(self) -> None:
+        result = self.backend.run_python_code("print('hello docker')", timeout_seconds=30.0)
+        self.assertEqual(result["exit_code"], 0)
+        self.assertIn("hello docker", result["stdout"])
+        self.assertEqual(result["sandbox"]["backend"], "docker")
+
+    def test_run_shell_uses_sh(self) -> None:
+        result = self.backend.run_shell("echo from docker", shell_binary="/bin/sh", timeout_seconds=30.0)
+        self.assertEqual(result["exit_code"], 0)
+        self.assertIn("from docker", result["stdout"])
+
+
+class AgentConfigSandboxFieldsTest(unittest.TestCase):
+    def test_default_is_local(self) -> None:
+        config = AgentConfig()
+        self.assertEqual(config.sandbox_backend, "local")
+        self.assertEqual(config.sandbox_image, "python:3.11-slim")
+
+    def test_explicit_docker_field_kept(self) -> None:
+        config = AgentConfig(sandbox_backend="docker", sandbox_memory_limit="512m")
+        self.assertEqual(config.sandbox_backend, "docker")
+        self.assertEqual(config.sandbox_memory_limit, "512m")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

LocalSandboxBackend 기본 유지 + DockerSandboxBackend 추가. opt-in이라 기존 환경 회귀 0. Docker 미설치 환경에서도 import는 깨지지 않음 (사용 시점에 가용성 확인 후 명시적 안내).

## 관련 이슈

Closes #18

## 변경 사항

신규 SandboxBackend Protocol — Local/Docker 둘 다 구현

DockerSandboxBackend:
- \`docker run --rm --network=none --memory=256m --cpus=1 --pids-limit=128 --read-only --tmpfs /tmp -v <host>:/workspace:ro\`
- 같은 정책 차단 (workspace_path / sensitive_absolute_path / dangerous_shell_pattern) — subprocess 전에 fire
- \`is_available()\` 클래스 메서드로 docker CLI 가용성 확인

config:
- \`sandbox_backend\` ('local' | 'docker') + image/memory/cpu/pids
- env override: \`ADAPTIVE_AGENT_SANDBOX_BACKEND\` 외 6개

registry:
- backend dispatch + Docker 미가용 시 명시적 RuntimeError + 잘못된 이름 ValueError

## 테스트 (12 신규, docker 미설치 환경에서는 2 skipped)

- [x] 기본 image / memory / cpu / pids
- [x] 정책 차단 3종 (Docker 데몬 없어도 fire)
- [x] registry 디스패치 (default local / invalid 거부 / docker 미가용 안내)
- [x] 실제 docker 실행 2건 (Docker 가능 시만 실행)
- [x] AgentConfig 필드 보존

\`\`\`
$ python -m unittest discover -s tests
Ran 137 tests in 0.917s — OK (skipped=2)
\`\`\`

## Base

\`feature/agent-core-stabilization\` (PR #21).