### PR TITLE
feat(llms): add streaming response method + CLI --stream flag

### DIFF
--- a/adaptive_agent/agent.py
+++ b/adaptive_agent/agent.py
@@ -108,6 +108,23 @@ class AdaptiveAgent:
         """Run one preserved user task through the state-machine router."""
         return self.router.run(task)
 
+    def stream_response(self, task: str):
+        """Yield raw LLM chunks for ``task``, bypassing planning/tool routing.
+
+        직접 자연어 응답을 stream으로 받아야 할 때 사용. Plan/JSON 흐름은
+        full string 파싱이 필요해 streaming 부적합 — 그래서 별도 entry.
+        Provider가 streaming 미지원이면 single-chunk로 회수된다.
+        """
+
+        stream_method = getattr(self.llm_client, "stream", None)
+        if stream_method is None:
+            # Stream 미지원 클라이언트 (예: 일부 stub) — complete 결과를 한 chunk로
+            yield self.llm_client.complete(task)
+            return
+        for chunk in stream_method(task):
+            if chunk:
+                yield chunk
+
     def run_tool(self, tool_name: str, arguments: dict[str, Any], *, _state: AgentState | None = None):
         """Execute an explicitly named tool without natural-language planning.
 

--- a/adaptive_agent/cli.py
+++ b/adaptive_agent/cli.py
@@ -70,6 +70,14 @@ def build_parser() -> argparse.ArgumentParser:
         default=None,
         help="재개한 pending 세션에 전달할 추가 입력",
     )
+    parser.add_argument(
+        "--stream",
+        action="store_true",
+        help=(
+            "자연어 task의 LLM 응답을 stdout에 streaming. plan/JSON 흐름을 "
+            "건너뛰고 직접 LLM 응답을 chunk로 받음 (디버깅·체크에 유용)."
+        ),
+    )
     return parser
 
 
@@ -141,6 +149,18 @@ def main(argv: Sequence[str] | None = None) -> int:
         parser.error("사용자 입력 원문 보존을 위해 task 전체를 따옴표로 감싸 하나의 인자로 전달하세요.")
 
     task = args.task[0]
+
+    if args.stream:
+        # Stream mode bypasses agent planning. JSON output disabled in this mode.
+        try:
+            for chunk in agent.stream_response(task):
+                print(chunk, end="", flush=True)
+            print()
+        except Exception as exc:
+            print(f"\nstream 실패: {exc}")
+            return 1
+        return 0
+
     result = agent.run(task)
     _print_result(result, args.json)
     return 0

--- a/adaptive_agent/llms/base.py
+++ b/adaptive_agent/llms/base.py
@@ -2,14 +2,24 @@
 
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Iterator, Protocol
 
 
 class LLMClient(Protocol):
-    """Minimum protocol implemented by LLM providers."""
+    """Minimum protocol implemented by LLM providers.
+
+    ``stream`` is opt-in; the default implementation in concrete clients
+    yields the full ``complete`` result in a single chunk so callers that
+    consume the iterator always work, even with providers that do not
+    natively stream. Provider-specific streaming (e.g. Ollama's chat
+    ``stream=True``) overrides this for true incremental output.
+    """
 
     def generate(self, prompt: str) -> str:
         """Generate text from a prompt."""
 
     def complete(self, prompt: str) -> str:
         """Compatibility completion method used by the agent core."""
+
+    def stream(self, prompt: str) -> Iterator[str]:
+        """Yield response chunks for a prompt; default = single chunk."""

--- a/adaptive_agent/llms/gemini_client.py
+++ b/adaptive_agent/llms/gemini_client.py
@@ -46,6 +46,11 @@ class GeminiClient:
 
         return self.generate(prompt)
 
+    def stream(self, prompt: str):
+        """Single-chunk fallback (Gemini SDK streaming은 별도 issue)."""
+
+        yield self.generate(prompt)
+
     def generate(self, prompt: str) -> str:
         from google import genai
 

--- a/adaptive_agent/llms/ollama.py
+++ b/adaptive_agent/llms/ollama.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import Iterator
+
 from adaptive_agent.llms.base import LLMClient
 
 
@@ -43,6 +45,26 @@ class OllamaClient:
         """Compatibility completion method used by the agent core."""
 
         return self.generate(prompt)
+
+    def stream(self, prompt: str) -> Iterator[str]:
+        """Stream chunks from Ollama natively (chat with stream=True)."""
+
+        import ollama
+
+        client_kwargs = {"timeout": self.timeout_seconds}
+        if self.host:
+            client_kwargs["host"] = self.host
+        client = ollama.Client(**client_kwargs)
+        stream = client.chat(
+            model=self.model,
+            messages=[{"role": "user", "content": prompt}],
+            options={"temperature": 0, "num_predict": self.num_predict},
+            stream=True,
+        )
+        for chunk in stream:
+            piece = chunk.get("message", {}).get("content", "")
+            if piece:
+                yield str(piece)
 
 
 def create_ollama_client(

--- a/adaptive_agent/llms/openai_client.py
+++ b/adaptive_agent/llms/openai_client.py
@@ -125,6 +125,27 @@ class OpenAIClient:
 
         return self.generate(prompt)
 
+    def stream(self, prompt: str):
+        """Stream OpenAI Chat Completions chunks (Responses API falls back to single chunk)."""
+
+        from openai import OpenAI
+
+        if should_use_openai_responses_api(self._model):
+            # Responses API streaming은 SDK 차이 큼 — 안전한 single-chunk fallback
+            yield self.generate(prompt)
+            return
+        client = OpenAI(api_key=self._api_key)
+        stream = client.chat.completions.create(
+            model=self._model,
+            messages=[{"role": "user", "content": prompt}],
+            stream=True,
+        )
+        for chunk in stream:
+            for choice in chunk.choices:
+                delta = getattr(choice.delta, "content", None)
+                if delta:
+                    yield delta
+
 
 def create_openai_client(model: str, *, api_key: str | None = None) -> LLMClient:
     return OpenAIClient(model=model, api_key=api_key)

--- a/tests/test_streaming.py
+++ b/tests/test_streaming.py
@@ -1,0 +1,111 @@
+"""Streaming LLM 응답 테스트.
+
+신규 LLMClient.stream() 프로토콜과 agent.stream_response() + CLI --stream
+플래그 검증. plan/JSON 흐름은 건드리지 않음.
+"""
+
+from __future__ import annotations
+
+import io
+import unittest
+from contextlib import redirect_stdout
+from unittest.mock import patch
+
+from adaptive_agent.agent import AdaptiveAgent
+from adaptive_agent.cli import main
+from adaptive_agent.config import AgentConfig
+
+
+class _ChunkStreamLLM:
+    """단일 chunks 리스트를 yield하는 stub."""
+
+    def __init__(self, chunks: list[str], complete_response: str = "fallback complete"):
+        self.chunks = chunks
+        self.complete_response = complete_response
+        self.complete_calls = 0
+        self.stream_calls = 0
+
+    def complete(self, _prompt: str) -> str:
+        self.complete_calls += 1
+        return self.complete_response
+
+    def generate(self, prompt: str) -> str:
+        return self.complete(prompt)
+
+    def stream(self, _prompt: str):
+        self.stream_calls += 1
+        yield from self.chunks
+
+
+class _NoStreamLLM:
+    """stream 메서드 없는 stub — fallback 검증용."""
+
+    def complete(self, _prompt: str) -> str:
+        return "no-stream fallback"
+
+    def generate(self, prompt: str) -> str:
+        return self.complete(prompt)
+
+
+class StreamResponseTest(unittest.TestCase):
+    def test_yields_provider_chunks_in_order(self) -> None:
+        llm = _ChunkStreamLLM(["Hel", "lo ", "world"])
+        agent = AdaptiveAgent(config=AgentConfig(), llm_client=llm)
+
+        chunks = list(agent.stream_response("greet"))
+
+        self.assertEqual(chunks, ["Hel", "lo ", "world"])
+        self.assertEqual(llm.stream_calls, 1)
+        self.assertEqual(llm.complete_calls, 0, "stream이 있으면 complete는 호출되지 않아야 함")
+
+    def test_falls_back_to_complete_when_provider_lacks_stream(self) -> None:
+        llm = _NoStreamLLM()
+        agent = AdaptiveAgent(config=AgentConfig(), llm_client=llm)
+
+        chunks = list(agent.stream_response("anything"))
+
+        self.assertEqual(chunks, ["no-stream fallback"])
+
+    def test_empty_chunks_are_filtered(self) -> None:
+        llm = _ChunkStreamLLM(["", "data", "", "more", ""])
+        agent = AdaptiveAgent(config=AgentConfig(), llm_client=llm)
+
+        chunks = list(agent.stream_response("x"))
+
+        self.assertEqual(chunks, ["data", "more"])
+
+
+class CLIStreamFlagTest(unittest.TestCase):
+    def test_stream_flag_prints_chunks_to_stdout(self) -> None:
+        buffer = io.StringIO()
+        chunks = ["First. ", "Second. ", "Third."]
+
+        with patch("adaptive_agent.cli.AdaptiveAgent") as agent_class, redirect_stdout(buffer):
+            agent_class.return_value.stream_response.return_value = iter(chunks)
+
+            exit_code = main(["--stream", "stream test"])
+
+        self.assertEqual(exit_code, 0)
+        output = buffer.getvalue()
+        self.assertIn("First. Second. Third.", output)
+
+    def test_stream_flag_handles_provider_exception(self) -> None:
+        buffer = io.StringIO()
+
+        def _raising_iter(*_args, **_kwargs):
+            yield "partial "
+            raise RuntimeError("provider boom")
+
+        with patch("adaptive_agent.cli.AdaptiveAgent") as agent_class, redirect_stdout(buffer):
+            agent_class.return_value.stream_response.return_value = _raising_iter()
+
+            exit_code = main(["--stream", "boom"])
+
+        self.assertEqual(exit_code, 1)
+        output = buffer.getvalue()
+        self.assertIn("partial", output)
+        self.assertIn("stream 실패", output)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 요약

LLMClient 프로토콜에 stream() 추가. plan/JSON 흐름은 그대로 두고 raw 응답 streaming은 별도 entry point (agent.stream_response, CLI --stream)로 분리. 미지원 provider는 single-chunk fallback으로 회귀 0.

## 관련 이슈

미추적 항목이었음 (블루프린트 Should: streaming 응답).

## 변경 사항

LLMClient 프로토콜:
- stream(prompt) -> Iterator[str] 추가

Provider:
- Ollama: 네이티브 stream=True chat 사용
- OpenAI: Chat Completions stream=True (Responses API는 SDK 차이로 single-chunk)
- Gemini: single-chunk fallback (별도 issue로 후속)

agent.py:
- stream_response(task): plan/router 우회, raw chunk 직접 yield
- stream 미지원 client는 자동으로 complete 결과를 single chunk로

cli.py:
- --stream 플래그: 자연어 task의 LLM 응답을 stdout에 streaming
- partial output + exception 안내 + exit 1

## 결정 (재확인)

- plan/critique/code 흐름은 streaming 부적합 (JSON 파싱 필요) — stream 진입점 분리
- Responses API streaming은 SDK 차이가 커 단순 single-chunk로 회귀 위험 차단

## 테스트 (5 신규)

- [x] chunk 순서 보존
- [x] stream 미지원 → complete fallback
- [x] 빈 chunk 필터링
- [x] CLI --stream printing
- [x] CLI --stream provider 예외 처리

\`\`\`
$ python -m unittest discover -s tests
Ran 130 tests in 0.975s — OK
\`\`\`

## Base

\`feature/agent-core-stabilization\` (PR #21).